### PR TITLE
Fix laser collision to not collide with owner

### DIFF
--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -390,7 +390,7 @@ void CGameContext::CreateSoundGlobal(int Sound, int Target)
 
 bool CGameContext::SnapLaserObject(const CSnapContext &Context, int SnapID, const vec2 &To, const vec2 &From, int StartTick, int Owner, int LaserType, int Subtype, int SwitchNumber)
 {
-	if(Context.GetClientVersion() >= VERSION_DDNET_MULTI_LASER)
+	if(Context.GetClientVersion() >= VERSION_DDNET_MULTI_LASER && false)
 	{
 		CNetObj_DDNetLaser *pObj = Server()->SnapNewItem<CNetObj_DDNetLaser>(SnapID);
 		if(!pObj)


### PR DESCRIPTION
Laser no longer collides with owner on clientside.
This code might be able to be better done, this also means that ddnet's fix for inconsistant wallbounce times at high in game time is no longer fixed clientside.
The other way this doesn't happen is if ddnet tiles prediction is disabled in the server flags send to the client, but that means no prediction on those. If the servers get restarted often enough this shouldn't be a problem ?

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
