### PR TITLE
fixed flag sounds being not per players perspective but per team

### DIFF
--- a/src/game/server/entities/flag.cpp
+++ b/src/game/server/entities/flag.cpp
@@ -5,6 +5,8 @@
 #include <game/server/gamecontext.h>
 #include <game/server/gamecontroller.h>
 
+#include <game/server/player.h>
+
 #include "flag.h"
 CFlag::CFlag(CGameWorld *pGameWorld, int Team) :
 	CEntity(pGameWorld, CGameWorld::ENTTYPE_FLAG)
@@ -34,7 +36,22 @@ void CFlag::Grab(CCharacter *pChar)
 	if(m_AtStand)
 		m_GrabTick = Server()->Tick();
 	m_AtStand = false;
-	GameServer()->CreateSoundGlobal(m_Team == TEAM_RED ? SOUND_CTF_GRAB_EN : SOUND_CTF_GRAB_PL);
+
+	for(int c = 0; c < MAX_CLIENTS; c++)
+	{
+		CPlayer *pPlayer = GameServer()->m_apPlayers[c];
+		if(!pPlayer)
+			continue;
+
+		if(pPlayer->GetTeam() == TEAM_SPECTATORS && pPlayer->m_SpectatorId != SPEC_FREEVIEW && GameServer()->m_apPlayers[pPlayer->m_SpectatorId]
+			&& GameServer()->m_apPlayers[pPlayer->m_SpectatorId]->GetTeam() == m_Team)
+			GameServer()->CreateSoundGlobal(SOUND_CTF_GRAB_EN, c);
+		else if(pPlayer->GetTeam() == m_Team)
+			GameServer()->CreateSoundGlobal(SOUND_CTF_GRAB_EN, c);
+		else
+			GameServer()->CreateSoundGlobal(SOUND_CTF_GRAB_PL, c);
+	}
+	// GameServer()->CreateSoundGlobal(m_Team == TEAM_RED ? SOUND_CTF_GRAB_EN : SOUND_CTF_GRAB_PL);
 }
 
 void CFlag::Drop()


### PR DESCRIPTION
Flag sounds should be dependent if your teams flag is stolen or the enemies
instead it was dependent on what team the flag was on. only being correct for red team.

## Checklist

- [X] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
