### PR TITLE
fix: fix ci

### DIFF
--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -34,11 +34,14 @@
 #include "score.h"
 
 // ddnet-insta
+#include <game/server/gamecontroller.h>
 #include <game/server/instagib/structs.h>
 
-#include <game/server/gamecontroller.h>
-
-decltype(g_Gamemodes) g_Gamemodes;
+GamemodesType &Gamemodes()
+{
+	static GamemodesType s_Gamemodes;
+	return s_Gamemodes;
+}
 
 // Not thread-safe!
 class CClientChatLogger : public ILogger
@@ -4150,7 +4153,7 @@ void CGameContext::OnInit(const void *pPersistentData)
 	}
 
 	m_pController = nullptr;
-	for(const auto &[String, Constructor] : g_Gamemodes)
+	for(const auto &[String, Constructor] : Gamemodes())
 	{
 		if(str_comp(Config()->m_SvGametype, String.c_str()) == 0)
 		{
@@ -4161,7 +4164,7 @@ void CGameContext::OnInit(const void *pPersistentData)
 	if(m_pController == nullptr)
 	{
 		log_warn("gametype", "unknown gametype '%s' falling back to ddnet", Config()->m_SvGametype);
-		m_pController = (g_Gamemodes["ddnet"])(this);
+		m_pController = (Gamemodes()["ddrace"])(this);
 	}
 
 	ReadCensorList();

--- a/src/game/server/gamecontext.h
+++ b/src/game/server/gamecontext.h
@@ -26,6 +26,11 @@
 #include <memory>
 #include <string>
 
+// ddnet-insta
+using GamemodesType = std::unordered_map<std::string, IGameController *(*)(CGameContext *)>;
+GamemodesType &Gamemodes();
+#define REGISTER_GAMEMODE(name, constructor) [[maybe_unused]] static auto s_Temp##name = ([]() {Gamemodes()[#name] = [](CGameContext *pGameServer) -> IGameController* { return new constructor; }; return 0; })();
+
 /*
 	Tick
 		Game Context (CGameContext::tick)
@@ -61,10 +66,6 @@ class IEngine;
 class IStorage;
 struct CAntibotRoundData;
 struct CScoreRandomMapResult;
-
-// ddnet-insta
-extern std::unordered_map<std::string, IGameController *(*)(CGameContext *)> g_Gamemodes;
-#define REGISTER_GAMEMODE(name, constructor) [[maybe_unused]] static auto s_Temp##name = ([]() {g_Gamemodes[#name] = [](CGameContext *pGameServer) -> IGameController* { return new constructor; }; return 0; })();
 
 struct CSnapContext
 {

--- a/src/game/server/gamemodes/instagib/tdm.cpp
+++ b/src/game/server/gamemodes/instagib/tdm.cpp
@@ -72,5 +72,3 @@ void CGameControllerInstaTDM::Snap(int SnappingClient)
 	pGameDataObj->m_FlagCarrierRed = 0;
 	pGameDataObj->m_FlagCarrierBlue = 0;
 }
-
-REGISTER_GAMEMODE(tdm, CGameControllerInstaTDM(pGameServer));


### PR DESCRIPTION
Broken by #405 and a turned head for CI

~~This adds back the DDRace gamemode to gamecontext.cpp for fallback. This should fix tests not having a gamemode to use as the test statically initalizes the gamemode before everything else~~

The problem was that the dictionary holding gamemodes was not initalized on windows compilers. The fix was making it a function that returns a static

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
