### PR TITLE
refactor: rename config_variables to config_variables_insta

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2060,6 +2060,7 @@ set_src(ENGINE_SHARED GLOB_RECURSE src/engine/shared
   config.cpp
   config.h
   config_variables.h
+  config_variables_insta.h
   console.cpp
   console.h
   csv.cpp
@@ -2134,7 +2135,6 @@ set_src(ENGINE_SHARED GLOB_RECURSE src/engine/shared
   translation_context.h
   uuid_manager.cpp
   uuid_manager.h
-  variables_insta.h
   video.cpp
   video.h
   websockets.cpp

--- a/src/engine/shared/config_variables.h
+++ b/src/engine/shared/config_variables.h
@@ -776,4 +776,4 @@ MACRO_CONFIG_INT(ClVideoRecorderFPS, cl_video_recorder_fps, 60, 1, 1000, CFGFLAG
  */
 
 // ddnet-insta
-#include "variables_insta.h"
+#include "config_variables_insta.h"

--- a/src/engine/shared/config_variables_insta.h
+++ b/src/engine/shared/config_variables_insta.h
@@ -1,10 +1,8 @@
-// ddnet-insta config variables
-#ifndef ENGINE_SHARED_VARIABLES_INSTA_H
-#define ENGINE_SHARED_VARIABLES_INSTA_H
-#undef ENGINE_SHARED_VARIABLES_INSTA_H // this file will be included several times
+// This file can be included several times.
 
 #ifndef MACRO_CONFIG_INT
 #error "The config macros must be defined"
+// This helps IDEs properly syntax highlight the uses of the macro below.
 #define MACRO_CONFIG_INT(Name, ScriptName, Def, Min, Max, Save, Desc) ;
 #define MACRO_CONFIG_COL(Name, ScriptName, Def, Save, Desc) ;
 #define MACRO_CONFIG_STR(Name, ScriptName, Len, Def, Save, Desc) ;
@@ -135,5 +133,3 @@ MACRO_CONFIG_INT(SvRoundStatsFormatDiscord, sv_round_stats_format_discord, 1, 0,
 MACRO_CONFIG_INT(SvRoundStatsFormatHttp, sv_round_stats_format_http, 4, 0, 4, CFGFLAG_SERVER, "0=csv 1=psv 2=ascii table 3=markdown table 4=json")
 MACRO_CONFIG_INT(SvRoundStatsFormatFile, sv_round_stats_format_file, 1, 0, 4, CFGFLAG_SERVER, "0=csv 1=psv 2=ascii table 3=markdown table 4=json")
 MACRO_CONFIG_INT(SvPrintRoundStats, sv_print_round_stats, 0, 0, 1, CFGFLAG_SERVER, "print top players in chat on round end")
-
-#endif

--- a/src/game/server/instagib/gamecontext.cpp
+++ b/src/game/server/instagib/gamecontext.cpp
@@ -189,7 +189,7 @@ void CGameContext::UpdateVoteCheckboxes() const
 	}
 #define MACRO_CONFIG_COL(Name, ScriptName, Def, Flags, Desc) // only int checkboxes for now
 #define MACRO_CONFIG_STR(Name, ScriptName, Len, Def, Flags, Desc) // only int checkboxes for now
-#include <engine/shared/variables_insta.h>
+#include <engine/shared/config_variables_insta.h>
 #undef MACRO_CONFIG_INT
 #undef MACRO_CONFIG_COL
 #undef MACRO_CONFIG_STR

--- a/src/game/server/instagib/rcon_configs.cpp
+++ b/src/game/server/instagib/rcon_configs.cpp
@@ -53,7 +53,7 @@ void CGameContext::RegisterInstagibCommands()
 	Console()->Chain(#ScriptName, ConchainInstaSettingsUpdate, this);
 #define MACRO_CONFIG_COL(Name, ScriptName, Def, Flags, Desc) // only int checkboxes for now
 #define MACRO_CONFIG_STR(Name, ScriptName, Len, Def, Flags, Desc) // only int checkboxes for now
-#include <engine/shared/variables_insta.h>
+#include <engine/shared/config_variables_insta.h>
 #undef MACRO_CONFIG_INT
 #undef MACRO_CONFIG_COL
 #undef MACRO_CONFIG_STR


### PR DESCRIPTION
1. rename variables_insta to config_variables_insta so that they are closer when sorted and to be more similar with the  multi config system in tclient
2. copy the preamble from config_variables (remove unneeded guard)

plz wait for CI

## Checklist

- [ ] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
