### PR TITLE
tsmash: fix a buncha crap

### DIFF
--- a/src/game/server/gamemodes/vanilla/tsmash/tsmash.cpp
+++ b/src/game/server/gamemodes/vanilla/tsmash/tsmash.cpp
@@ -103,13 +103,13 @@ void CGameControllerTsmash::SetTeeColor(CPlayer *pPlayer)
 	LastHealth = pCharacter->Health();
 	// Get color
 	ColorHSLA Color;
-	if(m_GameFlags & GAMEFLAG_TEAMS && pCharacter->Team() == TEAM_RED)
+	if(IsTeamPlay() && pCharacter->Team() == TEAM_RED)
 	{
 		static constexpr ColorRGBA RED = ColorRGBA(1.0f, 0.5f, 0.5f);
 		Color = color_cast<ColorHSLA>(RED);
 		Color.h += (float)(10 - pCharacter->Health()) / 10.0f * 0.3f;
 	}
-	else if(m_GameFlags & GAMEFLAG_TEAMS && pCharacter->Team() == TEAM_BLUE)
+	else if(IsTeamPlay() && pCharacter->Team() == TEAM_BLUE)
 	{
 		static constexpr ColorRGBA BLUE = ColorRGBA(0.7f, 0.7f, 1.0f);
 		Color = color_cast<ColorHSLA>(BLUE);

--- a/src/game/server/gamemodes/vanilla/tsmash/tsmash.cpp
+++ b/src/game/server/gamemodes/vanilla/tsmash/tsmash.cpp
@@ -205,6 +205,7 @@ void CGameControllerTsmash::Tick()
 		if(!pPlayer)
 			continue;
 		SetTeeColor(pPlayer);
+		pPlayer->ResetLastToucherAfterSeconds(5);
 	}
 	CGameControllerPvp::Tick();
 }

--- a/src/game/server/gamemodes/vanilla/tsmash/tsmash.cpp
+++ b/src/game/server/gamemodes/vanilla/tsmash/tsmash.cpp
@@ -197,24 +197,30 @@ void CGameControllerTsmash::Tick()
 
 void CGameControllerTsmash::OnAnyDamage(vec2 &Force, int &Dmg, int &From, int &Weapon, CCharacter *pCharacter)
 {
+	// Everything does 1 dmg
 	Dmg = 1;
-	float Scale = 1.0f;
-	Scale += (10.0f - (float)pCharacter->Health()) / 2.0f; // Low HP = more knockback
-	Scale -= (float)pCharacter->Armor() / 10.0f * 0.5f; // High Armor = less knockback
+	// Check for super smash
+	bool SuperSmash = false;
 	auto It = m_SuperSmash.find(From);
 	if(It != m_SuperSmash.end())
 	{
 		It->second->m_Number -= 1;
 		if(It->second->m_Number == 0)
 			m_SuperSmash.erase(It);
-		Scale += 15.0f;
 		CNetEvent_Explosion *pEvent = GameServer()->m_Events.Create<CNetEvent_Explosion>(pCharacter->TeamMask());
 		if(pEvent)
 		{
 			pEvent->m_X = (int)pCharacter->GetPos().x;
 			pEvent->m_Y = (int)pCharacter->GetPos().y;
 		}
+		SuperSmash = true;
 	}
+	// Calculate knockback increase
+	float Scale = 1.0f;
+	Scale += (10.0f - (float)pCharacter->Health()) / 2.0f; // Low HP = more knockback
+	Scale -= (float)pCharacter->Armor() / 10.0f * 0.5f; // High Armor = less knockback
+	if(SuperSmash)
+		Scale += 15.0f;
 	Force *= Scale;
 }
 

--- a/src/game/server/gamemodes/vanilla/tsmash/tsmash.cpp
+++ b/src/game/server/gamemodes/vanilla/tsmash/tsmash.cpp
@@ -211,13 +211,17 @@ void CGameControllerTsmash::Tick()
 
 void CGameControllerTsmash::OnAnyDamage(vec2 &Force, int &Dmg, int &From, int &Weapon, CCharacter *pCharacter)
 {
+	auto *pKiller = GetPlayerOrNullptr(From);
+	// Set last toucher
+	if(pKiller)
+		pCharacter->GetPlayer()->UpdateLastToucher(pKiller->GetCid());
 	// Everything does 1 dmg
 	Dmg = 1;
 	// Check for super smash
 	bool SuperSmash = false;
-	if(m_aSuperSmash[From])
+	if(pKiller && m_aSuperSmash[pKiller->GetCid()])
 	{
-		GiveSuperSmash(From, -1);
+		GiveSuperSmash(pKiller->GetCid(), -1);
 		CNetEvent_Explosion *pEvent = GameServer()->m_Events.Create<CNetEvent_Explosion>(pCharacter->TeamMask());
 		if(pEvent)
 		{

--- a/src/game/server/gamemodes/vanilla/tsmash/tsmash.cpp
+++ b/src/game/server/gamemodes/vanilla/tsmash/tsmash.cpp
@@ -168,16 +168,11 @@ int CGameControllerTsmash::OnCharacterDeath(class CCharacter *pVictim, class CPl
 {
 	// If this was a "self kill", change the weapon so scoring still happens
 	int ModeSpecial = CGameControllerVanilla::OnCharacterDeath(pVictim, pKiller, Weapon == WEAPON_WORLD ? WEAPON_HAMMER : Weapon);
-	// Do spree stuff
-	if(pKiller)
+	// On spree, reset health and get some armor so that the spree can go on
+	if(g_Config.m_SvKillingspreeKills > 0 && pKiller && pKiller->GetCharacter() && pKiller->Spree() % g_Config.m_SvKillingspreeKills == 0)
 	{
-		if(g_Config.m_SvKillingspreeKills > 0 && pKiller->Spree() % g_Config.m_SvKillingspreeKills == 0)
-		{
-			char aBuf[128];
-			str_format(aBuf, sizeof(aBuf), "Due to their spree, '%s' will have a super hammer for their next hit!", Server()->ClientName(pKiller->GetCid()));
-			GameServer()->SendChat(-1, TEAM_ALL, aBuf);
-			GiveSuperSmash(pKiller->GetCid(), 1);
-		}
+		pKiller->GetCharacter()->SetHealth(10);
+		pKiller->GetCharacter()->AddArmor(5);
 	}
 	if(pVictim)
 		m_aSuperSmash[pVictim->GetPlayer()->GetCid()] = nullptr;

--- a/src/game/server/gamemodes/vanilla/tsmash/tsmash.h
+++ b/src/game/server/gamemodes/vanilla/tsmash/tsmash.h
@@ -4,18 +4,19 @@
 #include "../../vanilla/base_vanilla.h"
 
 #include <memory>
-#include <unordered_map>
 
 class CGameControllerTsmash : public CGameControllerVanilla
 {
 private:
 	void SetTeeColor(CPlayer *pPlayer);
 	int m_aLastHealth[MAX_CLIENTS];
-	std::unordered_map<int, std::unique_ptr<CEntity>> m_SuperSmash;
+	std::unique_ptr<CEntity> m_aSuperSmash[MAX_CLIENTS];
 
 public:
 	CGameControllerTsmash(class CGameContext *pGameServer, bool Teams);
 	~CGameControllerTsmash() override;
+
+	void GiveSuperSmash(int ClientId, int Amount); // Amount can be negative
 
 	void OnCharacterDeathImpl(CCharacter *pVictim, int Killer, int Weapon, bool SendKillMsg) override;
 	int OnCharacterDeath(class CCharacter *pVictim, class CPlayer *pKiller, int Weapon) override;

--- a/src/game/server/gamemodes/vanilla/tsmash/tsmash.h
+++ b/src/game/server/gamemodes/vanilla/tsmash/tsmash.h
@@ -26,6 +26,7 @@ public:
 	void OnAnyDamage(vec2 &Force, int &Dmg, int &From, int &Weapon, CCharacter *pCharacter) override;
 	bool DecreaseHealthAndKill(int Dmg, int From, int Weapon, CCharacter *pCharacter) override;
 	bool OnSelfkill(int ClientId) override;
+	void Snap(int SnappingClient) override;
 };
 
 #endif


### PR DESCRIPTION
A buncha changes, see commit msgs

The only major thing is that spree now resets health and gives 5 armor instead of adding super hammer (super hammer now being unused)

Super hammer will be reintroduced as a pickup (like grenade) but isn't introduced in this PR due to complexity/size

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
