### PR TITLE
refactor: remove unnecesary win checks

### DIFF
--- a/src/game/server/gamemodes/base_pvp/ctf.cpp
+++ b/src/game/server/gamemodes/base_pvp/ctf.cpp
@@ -288,9 +288,6 @@ void CGameControllerBaseCTF::FlagTick()
 					GameServer()->CreateSoundGlobal(SOUND_CTF_CAPTURE);
 					for(CFlag *pF : m_apFlags)
 						pF->Reset();
-					// do a win check(capture could trigger win condition)
-					if(DoWincheckRound())
-						return;
 				}
 			}
 		}
@@ -352,7 +349,6 @@ void CGameControllerBaseCTF::FlagTick()
 			}
 		}
 	}
-	DoWincheckRound();
 }
 
 void CGameControllerBaseCTF::Snap(int SnappingClient)
@@ -402,37 +398,4 @@ void CGameControllerBaseCTF::Snap(int SnappingClient)
 		pGameDataObj->m_TeamscoreRed = m_aTeamscore[TEAM_RED];
 		pGameDataObj->m_TeamscoreBlue = m_aTeamscore[TEAM_BLUE];
 	}
-}
-
-bool CGameControllerBaseCTF::DoWincheckRound()
-{
-	if(IsWarmup())
-		return false;
-
-	CGameControllerPvp::DoWincheckRound();
-
-	// check score win condition
-	if((m_GameInfo.m_ScoreLimit > 0 && (m_aTeamscore[TEAM_RED] >= m_GameInfo.m_ScoreLimit || m_aTeamscore[TEAM_BLUE] >= m_GameInfo.m_ScoreLimit)) ||
-		(m_GameInfo.m_TimeLimit > 0 && (Server()->Tick() - m_GameStartTick) >= m_GameInfo.m_TimeLimit * Server()->TickSpeed() * 60))
-	{
-		if(m_SuddenDeath)
-		{
-			if(m_aTeamscore[TEAM_RED] / 100 != m_aTeamscore[TEAM_BLUE] / 100)
-			{
-				EndRound();
-				return true;
-			}
-		}
-		else
-		{
-			if(m_aTeamscore[TEAM_RED] != m_aTeamscore[TEAM_BLUE])
-			{
-				EndRound();
-				return true;
-			}
-			else
-				m_SuddenDeath = 1;
-		}
-	}
-	return false;
 }

--- a/src/game/server/gamemodes/base_pvp/ctf.h
+++ b/src/game/server/gamemodes/base_pvp/ctf.h
@@ -5,8 +5,6 @@
 
 class CGameControllerBaseCTF : public CGameControllerPvp
 {
-	bool DoWincheckRound() override;
-
 public:
 	CGameControllerBaseCTF(class CGameContext *pGameServer);
 	~CGameControllerBaseCTF() override;

--- a/src/game/server/gamemodes/instagib/ctf.cpp
+++ b/src/game/server/gamemodes/instagib/ctf.cpp
@@ -289,9 +289,6 @@ void CGameControllerInstaBaseCTF::FlagTick()
 
 					for(CFlag *pF : m_apFlags)
 						pF->Reset();
-					// do a win check(capture could trigger win condition)
-					if(DoWincheckRound())
-						return;
 				}
 			}
 		}
@@ -353,7 +350,6 @@ void CGameControllerInstaBaseCTF::FlagTick()
 			}
 		}
 	}
-	DoWincheckRound();
 }
 
 void CGameControllerInstaBaseCTF::Snap(int SnappingClient)
@@ -403,37 +399,4 @@ void CGameControllerInstaBaseCTF::Snap(int SnappingClient)
 		pGameDataObj->m_TeamscoreRed = m_aTeamscore[TEAM_RED];
 		pGameDataObj->m_TeamscoreBlue = m_aTeamscore[TEAM_BLUE];
 	}
-}
-
-bool CGameControllerInstaBaseCTF::DoWincheckRound()
-{
-	if(IsWarmup())
-		return false;
-
-	CGameControllerPvp::DoWincheckRound();
-
-	// check score win condition
-	if((m_GameInfo.m_ScoreLimit > 0 && (m_aTeamscore[TEAM_RED] >= m_GameInfo.m_ScoreLimit || m_aTeamscore[TEAM_BLUE] >= m_GameInfo.m_ScoreLimit)) ||
-		(m_GameInfo.m_TimeLimit > 0 && (Server()->Tick() - m_GameStartTick) >= m_GameInfo.m_TimeLimit * Server()->TickSpeed() * 60))
-	{
-		if(m_SuddenDeath)
-		{
-			if(m_aTeamscore[TEAM_RED] / 100 != m_aTeamscore[TEAM_BLUE] / 100)
-			{
-				EndRound();
-				return true;
-			}
-		}
-		else
-		{
-			if(m_aTeamscore[TEAM_RED] != m_aTeamscore[TEAM_BLUE])
-			{
-				EndRound();
-				return true;
-			}
-			else
-				m_SuddenDeath = 1;
-		}
-	}
-	return false;
 }

--- a/src/game/server/gamemodes/instagib/ctf.h
+++ b/src/game/server/gamemodes/instagib/ctf.h
@@ -5,8 +5,6 @@
 
 class CGameControllerInstaBaseCTF : public CGameControllerInstagib
 {
-	bool DoWincheckRound() override;
-
 public:
 	CGameControllerInstaBaseCTF(class CGameContext *pGameServer);
 	~CGameControllerInstaBaseCTF() override;

--- a/src/game/server/gamemodes/instagib/tdm.cpp
+++ b/src/game/server/gamemodes/instagib/tdm.cpp
@@ -18,8 +18,6 @@ void CGameControllerInstaTDM::Tick()
 
 int CGameControllerInstaTDM::OnCharacterDeath(class CCharacter *pVictim, class CPlayer *pKiller, int WeaponId)
 {
-	CGameControllerPvp::OnCharacterDeath(pVictim, pKiller, WeaponId);
-
 	if(pKiller && WeaponId != WEAPON_GAME)
 	{
 		// do team scoring
@@ -29,30 +27,7 @@ int CGameControllerInstaTDM::OnCharacterDeath(class CCharacter *pVictim, class C
 			AddTeamscore(pKiller->GetTeam() & 1, 1);
 	}
 
-	// check score win condition
-	if((m_GameInfo.m_ScoreLimit > 0 && (m_aTeamscore[TEAM_RED] >= m_GameInfo.m_ScoreLimit || m_aTeamscore[TEAM_BLUE] >= m_GameInfo.m_ScoreLimit)) ||
-		(m_GameInfo.m_TimeLimit > 0 && (Server()->Tick() - m_GameStartTick) >= m_GameInfo.m_TimeLimit * Server()->TickSpeed() * 60))
-	{
-		if(m_SuddenDeath)
-		{
-			if(m_aTeamscore[TEAM_RED] / 100 != m_aTeamscore[TEAM_BLUE] / 100)
-			{
-				EndRound();
-				return true;
-			}
-		}
-		else
-		{
-			if(m_aTeamscore[TEAM_RED] != m_aTeamscore[TEAM_BLUE])
-			{
-				EndRound();
-				return true;
-			}
-			else
-				m_SuddenDeath = 1;
-		}
-	}
-	return false;
+	return CGameControllerPvp::OnCharacterDeath(pVictim, pKiller, WeaponId);
 }
 
 void CGameControllerInstaTDM::Snap(int SnappingClient)


### PR DESCRIPTION
There's some duplicated checks for win code and extra calls to winchecking as a whole

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
