### PR TITLE
fix: fix segfault on unknown gametype

### DIFF
--- a/src/game/server/gamecontext.cpp
+++ b/src/game/server/gamecontext.cpp
@@ -4164,7 +4164,7 @@ void CGameContext::OnInit(const void *pPersistentData)
 	if(m_pController == nullptr)
 	{
 		log_warn("gametype", "unknown gametype '%s' falling back to ddnet", Config()->m_SvGametype);
-		m_pController = (Gamemodes()["ddrace"])(this);
+		m_pController = (Gamemodes()["ddnet"])(this);
 	}
 
 	ReadCensorList();


### PR DESCRIPTION
I put `ddrace` instead of `ddnet` for fallback, this doesn't exist and causes a segfault ):

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or valgrind's memcheck](https://github.com/ddnet/ddnet/#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
