### PR TITLE
 refactor: new skin override system

### DIFF
--- a/CMakeLists.txt
+++ b/CMakeLists.txt
@@ -2930,6 +2930,8 @@ if(SERVER)
     instagib/round_stats_ascii.cpp
     instagib/round_stats_csv.cpp
     instagib/round_stats_player.h
+    instagib/skin_info_manager.cpp
+    instagib/skin_info_manager.h
     instagib/sql_columns_all.h
     instagib/sql_stats.cpp
     instagib/sql_stats.h

--- a/src/game/server/gamemodes/base_pvp/character.cpp
+++ b/src/game/server/gamemodes/base_pvp/character.cpp
@@ -174,32 +174,9 @@ void CCharacter::Rainbow(bool Activate)
 	m_Rainbow = Activate;
 
 	if(Activate)
-	{
-		GetPlayer()->m_TeeInfosNoCosmetics = GetPlayer()->m_TeeInfos;
-		return;
-	}
-
-	GetPlayer()->m_TeeInfos = GetPlayer()->m_TeeInfosNoCosmetics;
-	GetPlayer()->m_TeeInfos.ToSixup();
-
-	protocol7::CNetMsg_Sv_SkinChange Msg;
-	Msg.m_ClientId = GetPlayer()->GetCid();
-	for(int p = 0; p < protocol7::NUM_SKINPARTS; p++)
-	{
-		Msg.m_apSkinPartNames[p] = GetPlayer()->m_TeeInfos.m_aaSkinPartNames[p];
-		Msg.m_aSkinPartColors[p] = GetPlayer()->m_TeeInfos.m_aSkinPartColors[p];
-		Msg.m_aUseCustomColors[p] = GetPlayer()->m_TeeInfos.m_aUseCustomColors[p];
-	}
-
-	for(CPlayer *pRainbowReceiverPlayer : GameServer()->m_apPlayers)
-	{
-		if(!pRainbowReceiverPlayer)
-			continue;
-		if(!Server()->IsSixup(pRainbowReceiverPlayer->GetCid()))
-			continue;
-
-		Server()->SendPackMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, pRainbowReceiverPlayer->GetCid());
-	}
+		GetPlayer()->m_SkinInfoManager.SetUseCustomColor(ESkinPrio::RAINBOW, true);
+	else
+		GetPlayer()->m_SkinInfoManager.UnsetAll(ESkinPrio::RAINBOW);
 }
 
 void CCharacter::PlayerGetBall()

--- a/src/game/server/gamemodes/base_pvp/player.h
+++ b/src/game/server/gamemodes/base_pvp/player.h
@@ -8,6 +8,7 @@
 
 #include <game/server/instagib/enums.h>
 #include <game/server/instagib/ip_storage.h>
+#include <game/server/instagib/skin_info_manager.h>
 #include <game/server/instagib/sql_stats.h>
 #include <game/server/instagib/sql_stats_player.h>
 #include <game/server/instagib/structs.h>
@@ -32,10 +33,6 @@ public:
 	int m_RainbowColor = 0;
 
 	std::optional<CIpStorage> m_IpStorage;
-
-	// backup of the players skin
-	// for when cosmetics like rainbow are turned off
-	CTeeInfo m_TeeInfosNoCosmetics;
 
 	void ProcessStatsResult(CInstaSqlResult &Result);
 
@@ -339,12 +336,7 @@ public:
 	bool m_IsBomb = false;
 	int m_ToBombTick = 0;
 
-	std::unique_ptr<CTeeInfo> m_FakeTeeInfos;
-	void SetFakeSkin(const char *pSkinName);
-	void SetFakeSkin(const char *pSkinName, int UseCustomColor, int ColorBody, int ColorFeet);
-	CTeeInfo *GetSkin() { return m_FakeTeeInfos ? m_FakeTeeInfos.get() : &m_TeeInfos; }
-	void DeleteFakeSkin();
-	bool HasFakeSkin();
+	CSkinInfoManager m_SkinInfoManager;
 
 	// needed for clang to avoid redundant access specifier
 private:

--- a/src/game/server/gamemodes/insta_core/insta_core.cpp
+++ b/src/game/server/gamemodes/insta_core/insta_core.cpp
@@ -35,7 +35,6 @@ CGameControllerInstaCore::CGameControllerInstaCore(class CGameContext *pGameServ
 	log_info("ddnet-insta", "initializing insta core ...");
 
 	UpdateSpawnWeapons(true, true);
-	m_AllowSkinColorChange = true;
 	m_vFrozenQuitters.clear();
 	g_AntibobContext.m_pConsole = Console();
 }
@@ -311,19 +310,23 @@ void CGameControllerInstaCore::Tick()
 		OnCharacterTick(pPlayer->GetCharacter());
 
 		// ratelimit the 0.7 stuff because it requires net messages
-		if(Config()->m_SvSixup && Server()->Tick() % 4 == 0 && Server()->IsSixup(pPlayer->GetCid()))
+		if(Server()->Tick() % 4 == 0)
 		{
-			CTeeInfo *pTeeInfo = pPlayer->GetSkin();
-			protocol7::CNetMsg_Sv_SkinChange Msg;
-			Msg.m_ClientId = pPlayer->GetCid();
-			for(int p = 0; p < protocol7::NUM_SKINPARTS; p++)
+			if(pPlayer->m_SkinInfoManager.NeedsNetMessage7())
 			{
-				Msg.m_apSkinPartNames[p] = pTeeInfo->m_aaSkinPartNames[p];
-				Msg.m_aSkinPartColors[p] = pTeeInfo->m_aSkinPartColors[p];
-				Msg.m_aUseCustomColors[p] = pTeeInfo->m_aUseCustomColors[p];
+				pPlayer->m_SkinInfoManager.OnSendNetMessage7();
+				CTeeInfo TeeInfo = pPlayer->m_SkinInfoManager.TeeInfo();
+				protocol7::CNetMsg_Sv_SkinChange Msg;
+				Msg.m_ClientId = pPlayer->GetCid();
+				for(int p = 0; p < protocol7::NUM_SKINPARTS; p++)
+				{
+					Msg.m_apSkinPartNames[p] = TeeInfo.m_aaSkinPartNames[p];
+					Msg.m_aSkinPartColors[p] = TeeInfo.m_aSkinPartColors[p];
+					Msg.m_aUseCustomColors[p] = TeeInfo.m_aUseCustomColors[p];
+				}
+				bool NetworkClip = pPlayer->GetCharacter()->HasRainbow();
+				SendSkinChangeToAllSixup(&Msg, pPlayer, NetworkClip);
 			}
-
-			Server()->SendPackMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, -1);
 		}
 	}
 
@@ -523,21 +526,15 @@ bool CGameControllerInstaCore::OnSkinChange7(protocol7::CNetMsg_Cl_SkinChange *p
 {
 	CPlayer *pPlayer = GameServer()->m_apPlayers[ClientId];
 
-	CTeeInfo Info(pMsg->m_apSkinPartNames, pMsg->m_aUseCustomColors, pMsg->m_aSkinPartColors);
-	Info.FromSixup();
+	// parse 0.7 info
+	pPlayer->m_TeeInfos = CTeeInfo(pMsg->m_apSkinPartNames, pMsg->m_aUseCustomColors, pMsg->m_aSkinPartColors);
+	pPlayer->m_TeeInfos.FromSixup();
 
-	CTeeInfo OldInfo = pPlayer->m_TeeInfos;
-	pPlayer->m_TeeInfos = Info;
+	// store user request
+	pPlayer->m_SkinInfoManager.SetUserChoice(pPlayer->m_TeeInfos);
 
-	// restore old color
-	if(!IsSkinColorChangeAllowed())
-	{
-		for(int p = 0; p < protocol7::NUM_SKINPARTS; p++)
-		{
-			pPlayer->m_TeeInfos.m_aSkinPartColors[p] = OldInfo.m_aSkinPartColors[p];
-			pPlayer->m_TeeInfos.m_aUseCustomColors[p] = OldInfo.m_aUseCustomColors[p];
-		}
-	}
+	// enforce server set info
+	pPlayer->m_TeeInfos = pPlayer->m_SkinInfoManager.TeeInfo();
 
 	protocol7::CNetMsg_Sv_SkinChange Msg;
 	Msg.m_ClientId = ClientId;
@@ -708,13 +705,15 @@ void CGameControllerInstaCore::SnapPlayer6(int SnappingClient, CPlayer *pPlayer,
 		StrToInts(pClientInfo->m_aName, std::size(pClientInfo->m_aName), aReady);
 	}
 
-	if(pPlayer->HasFakeSkin())
-	{
-		StrToInts(pClientInfo->m_aSkin, std::size(pClientInfo->m_aSkin), pPlayer->m_FakeTeeInfos->m_aSkinName);
-		pClientInfo->m_UseCustomColor = pPlayer->m_FakeTeeInfos->m_UseCustomColor;
-		pClientInfo->m_ColorBody = pPlayer->m_FakeTeeInfos->m_ColorBody;
-		pClientInfo->m_ColorFeet = pPlayer->m_FakeTeeInfos->m_ColorFeet;
-	}
+	// TODO: can we save clock cycles here?
+	//       maybe only set it if the skin info manager has custom values
+	//       something like if(pPlayer->m_SkinInfoManager.HasValues())
+	//       which is just a cheap bool lookup
+	CTeeInfo Info = pPlayer->m_SkinInfoManager.TeeInfo();
+	StrToInts(pClientInfo->m_aSkin, std::size(pClientInfo->m_aSkin), Info.m_aSkinName);
+	pClientInfo->m_UseCustomColor = Info.m_UseCustomColor;
+	pClientInfo->m_ColorBody = Info.m_ColorBody;
+	pClientInfo->m_ColorFeet = Info.m_ColorFeet;
 }
 
 void CGameControllerInstaCore::SnapDDNetPlayer(int SnappingClient, CPlayer *pPlayer, CNetObj_DDNetPlayer *pDDNetPlayer)
@@ -820,6 +819,36 @@ void CGameControllerInstaCore::OnCharacterTick(CCharacter *pChr)
 {
 	if(pChr->GetPlayer()->m_PlayerFlags & PLAYERFLAG_CHATTING)
 		pChr->GetPlayer()->m_TicksSpentChatting++;
+}
+
+void CGameControllerInstaCore::SendSkinChangeToAllSixup(protocol7::CNetMsg_Sv_SkinChange *pMsg, CPlayer *pPlayer, bool ApplyNetworkClipping)
+{
+	if(!pPlayer->GetCharacter())
+		return;
+
+	if(!ApplyNetworkClipping)
+	{
+		Server()->SendPackMsg(pMsg, MSGFLAG_VITAL | MSGFLAG_NORECORD, -1);
+		return;
+	}
+
+	for(CPlayer *pReceivingPlayer : GameServer()->m_apPlayers)
+	{
+		if(!pReceivingPlayer)
+			continue;
+		if(!Server()->IsSixup(pReceivingPlayer->GetCid()))
+			continue;
+
+		const bool IsTopscorer = !GameServer()->m_pController->IsTeamPlay() && GameServer()->m_pController->HasWinningScore(pPlayer);
+
+		// never clip when in scoreboard or the top scorer
+		// to see the rainbow in scoreboard and hud in the bottom right
+		if(!(pReceivingPlayer->m_PlayerFlags & PLAYERFLAG_SCOREBOARD) && !IsTopscorer)
+			if(NetworkClipped(GameServer(), pReceivingPlayer->GetCid(), pPlayer->GetCharacter()->GetPos()))
+				continue;
+
+		Server()->SendPackMsg(pMsg, MSGFLAG_VITAL | MSGFLAG_NORECORD, pReceivingPlayer->GetCid());
+	}
 }
 
 void CGameControllerInstaCore::UpdateSpawnWeapons(bool Silent, bool Apply)

--- a/src/game/server/gamemodes/insta_core/insta_core.h
+++ b/src/game/server/gamemodes/insta_core/insta_core.h
@@ -3,6 +3,8 @@
 
 #include "../DDRace.h"
 
+#include <generated/protocol7.h>
+
 #include <game/server/instagib/extra_columns.h>
 #include <game/server/instagib/sql_stats.h>
 #include <game/server/player.h>
@@ -94,6 +96,11 @@ public:
 private:
 	bool m_InvalidateConnectedIpsCache = true;
 	int m_NumConnectedIpsCached = 0;
+
+	// pPlayer is the player whose skin changed
+	// not the receiver of the message
+	// the message is sent to all 0.7 players that are in clip region
+	void SendSkinChangeToAllSixup(protocol7::CNetMsg_Sv_SkinChange *pMsg, CPlayer *pPlayer, bool ApplyNetworkClipping);
 
 public:
 	/* UpdateSpawnWeapons

--- a/src/game/server/gamemodes/instagib/base_instagib.cpp
+++ b/src/game/server/gamemodes/instagib/base_instagib.cpp
@@ -20,7 +20,6 @@ CGameControllerInstagib::CGameControllerInstagib(class CGameContext *pGameServer
 	m_GameFlags = GAMEFLAG_TEAMS | GAMEFLAG_FLAGS;
 	m_IsVanillaGameType = false;
 	m_SelfDamage = false;
-	m_AllowSkinColorChange = true;
 }
 
 CGameControllerInstagib::~CGameControllerInstagib() = default;

--- a/src/game/server/gamemodes/instagib/zcatch/colors.cpp
+++ b/src/game/server/gamemodes/instagib/zcatch/colors.cpp
@@ -2,14 +2,12 @@
 
 #include <engine/shared/config.h>
 
+#include <generated/protocol.h>
+
 #include <game/server/entities/character.h>
+#include <game/server/instagib/skin_info_manager.h>
 #include <game/server/player.h>
 #include <game/server/teeinfo.h>
-
-static int ColorToSixup(int Color6)
-{
-	return ColorHSLA(Color6).UnclampLighting(ColorHSLA::DARKEST_LGT).Pack(ColorHSLA::DARKEST_LGT7);
-}
 
 int CGameControllerZcatch::GetBodyColorTeetime(int Kills)
 {
@@ -85,77 +83,22 @@ void CGameControllerZcatch::OnUpdateZcatchColorConfig()
 			aBuf);
 		str_copy(Config()->m_SvZcatchColors, "teetime");
 	}
+
+	for(CPlayer *pPlayer : GameServer()->m_apPlayers)
+		if(pPlayer && pPlayer->GetTeam() != TEAM_SPECTATORS)
+			SetCatchColors(pPlayer);
 }
 
 void CGameControllerZcatch::SetCatchColors(CPlayer *pPlayer)
 {
-	if(pPlayer->GetCharacter() && pPlayer->GetCharacter()->HasRainbow())
-		return;
-
 	int Color = GetBodyColor(pPlayer->m_KillsThatCount);
 
 	// it would be cleaner if this only applied to the winner
 	// we could make sure m_KillsThatCount is not reset until the next round starts
 	// but for now it should work because players that connect during round end
-	// will reset m_aBodyColors
+	// will reset colors
 	if(GameState() == IGS_END_ROUND)
-		Color = m_aBodyColors[pPlayer->GetCid()];
-
-	// 0.6
-	pPlayer->m_TeeInfos.m_ColorBody = Color;
-	pPlayer->m_TeeInfos.m_UseCustomColor = true;
-
-	// 0.7
-	for(int p = 0; p < protocol7::NUM_SKINPARTS; p++)
-	{
-		pPlayer->m_TeeInfos.m_aSkinPartColors[p] = ColorToSixup(Color);
-		pPlayer->m_TeeInfos.m_aUseCustomColors[p] = true;
-	}
-}
-
-bool CGameControllerZcatch::OnChangeInfoNetMessage(const CNetMsg_Cl_ChangeInfo *pMsg, int ClientId)
-{
-	if(ClientId < 0 || ClientId >= MAX_CLIENTS)
-		return false;
-
-	CPlayer *pPlayer = GameServer()->m_apPlayers[ClientId];
-	if(!pPlayer)
-		return false;
-
-	SetCatchColors(pPlayer);
-	return false;
-}
-
-void CGameControllerZcatch::SendSkinBodyColor7(int ClientId, int Color)
-{
-	if(ClientId < 0 || ClientId >= MAX_CLIENTS)
 		return;
 
-	CPlayer *pPlayer = GameServer()->m_apPlayers[ClientId];
-	if(!pPlayer)
-		return;
-	if(pPlayer->GetCharacter() && pPlayer->GetCharacter()->HasRainbow())
-		return;
-
-	// also update 0.6 just to be sure
-	pPlayer->m_TeeInfos.m_ColorBody = Color;
-	pPlayer->m_TeeInfos.m_UseCustomColor = true;
-
-	// 0.7
-	for(int p = 0; p < protocol7::NUM_SKINPARTS; p++)
-	{
-		pPlayer->m_TeeInfos.m_aSkinPartColors[p] = ColorToSixup(Color);
-		pPlayer->m_TeeInfos.m_aUseCustomColors[p] = true;
-	}
-
-	protocol7::CNetMsg_Sv_SkinChange Msg;
-	Msg.m_ClientId = ClientId;
-	for(int p = 0; p < protocol7::NUM_SKINPARTS; p++)
-	{
-		Msg.m_apSkinPartNames[p] = pPlayer->m_TeeInfos.m_aaSkinPartNames[p];
-		Msg.m_aSkinPartColors[p] = pPlayer->m_TeeInfos.m_aSkinPartColors[p];
-		Msg.m_aUseCustomColors[p] = pPlayer->m_TeeInfos.m_aUseCustomColors[p];
-	}
-
-	Server()->SendPackMsg(&Msg, MSGFLAG_VITAL | MSGFLAG_NORECORD, -1);
+	pPlayer->m_SkinInfoManager.SetColorBody(ESkinPrio::LOW, Color);
 }

--- a/src/game/server/gamemodes/instagib/zcatch/zcatch.h
+++ b/src/game/server/gamemodes/instagib/zcatch/zcatch.h
@@ -115,7 +115,6 @@ public:
 	void OnRoundStart() override;
 	void OnRoundEnd() override;
 	bool OnSelfkill(int ClientId) override;
-	bool OnChangeInfoNetMessage(const CNetMsg_Cl_ChangeInfo *pMsg, int ClientId) override;
 	int GetPlayerTeam(class CPlayer *pPlayer, bool Sixup) override;
 	bool OnSetTeamNetMessage(const CNetMsg_Cl_SetTeam *pMsg, int ClientId) override;
 	bool IsWinner(const CPlayer *pPlayer, char *pMessage, int SizeOfMessage) override;
@@ -194,7 +193,6 @@ public:
 	int GetBodyColorSavander(int Kills);
 
 	void SetCatchColors(class CPlayer *pPlayer);
-	void SendSkinBodyColor7(int ClientId, int Color);
 	void OnUpdateZcatchColorConfig() override;
 
 	// returns nullptr if nobody made a kill yet that counts

--- a/src/game/server/gamemodes/vanilla/base_vanilla.cpp
+++ b/src/game/server/gamemodes/vanilla/base_vanilla.cpp
@@ -20,7 +20,6 @@ CGameControllerVanilla::CGameControllerVanilla(class CGameContext *pGameServer) 
 {
 	m_GameFlags = 0;
 	m_IsVanillaGameType = true;
-	m_AllowSkinColorChange = true;
 	m_DefaultWeapon = WEAPON_GUN;
 }
 

--- a/src/game/server/gamemodes/vanilla/bomb/bomb.cpp
+++ b/src/game/server/gamemodes/vanilla/bomb/bomb.cpp
@@ -7,6 +7,7 @@
 #include <game/mapitems.h>
 #include <game/server/entities/character.h>
 #include <game/server/gamecontext.h>
+#include <game/server/instagib/skin_info_manager.h>
 
 #include <random>
 
@@ -323,30 +324,25 @@ void CGameControllerBomb::SetSkin(CPlayer *pPlayer)
 {
 	if(pPlayer->m_IsBomb)
 	{
+		// TODO: dont copy this string on tick but only when the bomb changes
+		pPlayer->m_SkinInfoManager.SetSkinName(ESkinPrio::HIGH, "bomb");
 		if(pPlayer->m_ToBombTick <= 3 * Server()->TickSpeed())
 		{
 			ColorRGBA Color = ColorRGBA(255 - pPlayer->m_ToBombTick, 0, 0);
-			pPlayer->SetFakeSkin(
-				"bomb",
-				true,
-				color_cast<ColorHSLA>(Color).PackAlphaLast(false),
-				16777215 // white
-			);
+			pPlayer->m_SkinInfoManager.SetColorBody(ESkinPrio::HIGH, color_cast<ColorHSLA>(Color).PackAlphaLast(false));
+			pPlayer->m_SkinInfoManager.SetColorFeet(ESkinPrio::HIGH, 16777215); // white
+			pPlayer->m_SkinInfoManager.SetUseCustomColor(ESkinPrio::HIGH, true);
 		}
-		else
-			pPlayer->SetFakeSkin("bomb");
 		return;
 	}
 
 	// Ignores manual installation of the bomb skin
-	if(str_comp_nocase(pPlayer->m_TeeInfos.m_aSkinName, "bomb") == 0)
+	if(str_comp_nocase(pPlayer->m_SkinInfoManager.UserChoice().m_aSkinName, "bomb") == 0)
 	{
-		pPlayer->SetFakeSkin("default");
+		pPlayer->m_SkinInfoManager.SetSkinName(ESkinPrio::HIGH, "default");
 		return;
 	}
-
-	if(pPlayer->HasFakeSkin())
-		pPlayer->DeleteFakeSkin();
+	pPlayer->m_SkinInfoManager.UnsetAll(ESkinPrio::HIGH);
 }
 
 void CGameControllerBomb::EliminatePlayer(CPlayer *pPlayer, bool Collateral)

--- a/src/game/server/gamemodes/vanilla/ctf/ctf.cpp
+++ b/src/game/server/gamemodes/vanilla/ctf/ctf.cpp
@@ -15,7 +15,6 @@ CGameControllerCTF::CGameControllerCTF(class CGameContext *pGameServer) :
 	m_pGameType = "CTF*";
 	m_IsVanillaGameType = true;
 	m_GameFlags = GAMEFLAG_TEAMS | GAMEFLAG_FLAGS;
-	m_AllowSkinColorChange = true;
 	m_DefaultWeapon = WEAPON_GUN;
 
 	m_pStatsTable = "ctf";

--- a/src/game/server/gamemodes/vanilla/tsmash/tsmash.cpp
+++ b/src/game/server/gamemodes/vanilla/tsmash/tsmash.cpp
@@ -100,11 +100,6 @@ void CGameControllerTsmash::GiveSuperSmash(int ClientId, int Amount)
 	}
 }
 
-static int ColorToSixup(int Color6)
-{
-	return ColorHSLA(Color6).UnclampLighting(ColorHSLA::DARKEST_LGT).Pack(ColorHSLA::DARKEST_LGT7);
-}
-
 void CGameControllerTsmash::SetTeeColor(CPlayer *pPlayer)
 {
 	auto *pCharacter = pPlayer->GetCharacter();
@@ -132,17 +127,11 @@ void CGameControllerTsmash::SetTeeColor(CPlayer *pPlayer)
 	{
 		Color = ColorHSLA((float)(10 - pCharacter->Health()) / 10.0f * 0.75f + 0.25f, 1.0f, 0.5f);
 	}
-	// 0.6
-	auto Color6 = Color.Pack();
-	pPlayer->m_TeeInfos.m_UseCustomColor = true;
-	pPlayer->m_TeeInfos.m_ColorBody = Color6;
-	pPlayer->m_TeeInfos.m_ColorFeet = Color6;
-	// 0.7
-	for(bool &UseCustomColor : pPlayer->m_TeeInfos.m_aUseCustomColors)
-		UseCustomColor = true;
-	const int Color7 = ColorToSixup(Color6);
-	for(int &PartColor : pPlayer->m_TeeInfos.m_aSkinPartColors)
-		PartColor = Color7;
+
+	int ColorVal = Color.Pack();
+	pPlayer->m_SkinInfoManager.SetUseCustomColor(ESkinPrio::LOW, true);
+	pPlayer->m_SkinInfoManager.SetColorBody(ESkinPrio::LOW, ColorVal);
+	pPlayer->m_SkinInfoManager.SetColorFeet(ESkinPrio::LOW, ColorVal);
 }
 
 CGameControllerTsmash::CGameControllerTsmash(class CGameContext *pGameServer, bool Teams) :

--- a/src/game/server/instagib/gamecontroller.h
+++ b/src/game/server/instagib/gamecontroller.h
@@ -1247,8 +1247,6 @@ public:
 	bool HasEnoughPlayers() const { return (IsTeamPlay() && m_aTeamSize[TEAM_RED] > 0 && m_aTeamSize[TEAM_BLUE] > 0) || (!IsTeamPlay() && m_aTeamSize[TEAM_RED] > 1); }
 	void SetGameState(EGameState GameState, int Timer = 0);
 
-	bool m_AllowSkinColorChange = true;
-
 	// protected:
 	struct CGameInfo
 	{
@@ -1321,7 +1319,6 @@ public:
 	// depends on the base pvp controller to tick
 	int m_TicksUntilShutdown = 0;
 
-	bool IsSkinColorChangeAllowed() const { return m_AllowSkinColorChange; }
 	int GameFlags() const { return m_GameFlags; }
 	void CheckGameInfo();
 	bool IsFriendlyFire(int ClientId1, int ClientId2) const;

--- a/src/game/server/instagib/skin_info_manager.cpp
+++ b/src/game/server/instagib/skin_info_manager.cpp
@@ -1,0 +1,167 @@
+#include "skin_info_manager.h"
+
+#include <base/str.h>
+
+#include <game/client/skin.h>
+#include <game/server/teeinfo.h>
+
+#include <optional>
+
+bool CSkinOverrideRequest::HasAnyValue()
+{
+	return m_SkinName.has_value() ||
+	       m_ColorBody.has_value() ||
+	       m_ColorFeet.has_value() ||
+	       m_UseCustomColor.has_value();
+}
+
+// CSkinInfoManager::CSkinInfoManager()
+// {
+// 	m_aOverrideRequests[(int)ESkinPrio::RAINBOW].m_NetworkClipped = true;
+// }
+
+bool CSkinInfoManager::NeedsNetMessage7()
+{
+	// TODO: use cached reference to avoid duplicated memory copy
+	CTeeInfo Info = TeeInfo();
+
+	// TODO: checking 0.6 values for 0.7 update makes little sense
+	//       but it kinda works because we translate it first
+
+	if(str_comp(m_LastInfoSent7.m_aSkinName, Info.m_aSkinName))
+		return true;
+	if(m_LastInfoSent7.m_ColorBody != Info.m_ColorBody)
+		return true;
+	if(m_LastInfoSent7.m_ColorFeet != Info.m_ColorFeet)
+		return true;
+	if(m_LastInfoSent7.m_UseCustomColor != Info.m_UseCustomColor)
+		return true;
+
+	return false;
+}
+
+void CSkinInfoManager::OnSendNetMessage7()
+{
+	// TODO: use cached reference to avoid duplicated memory copy
+	CTeeInfo Info = TeeInfo();
+
+	// TODO: storing 0.6 values for 0.7 update makes little sense
+	//       but it kinda works because we translate it first
+	str_copy(m_LastInfoSent7.m_aSkinName, Info.m_aSkinName);
+	m_LastInfoSent7.m_ColorBody = Info.m_ColorBody;
+	m_LastInfoSent7.m_ColorFeet = Info.m_ColorFeet;
+	m_LastInfoSent7.m_UseCustomColor = Info.m_UseCustomColor;
+}
+
+void CSkinInfoManager::SetUserChoice(CTeeInfo Info)
+{
+	m_TeeInfoUserChoice = Info;
+}
+
+void CSkinInfoManager::SetSkinName(ESkinPrio Priority, const char *pSkinName)
+{
+	m_aOverrideRequests[(int)Priority].m_SkinName = std::string(pSkinName);
+}
+
+void CSkinInfoManager::UnsetSkinName(ESkinPrio Priority)
+{
+	m_aOverrideRequests[(int)Priority].m_SkinName = std::nullopt;
+}
+
+void CSkinInfoManager::SetColorBody(ESkinPrio Priority, int Color)
+{
+	m_aOverrideRequests[(int)Priority].m_ColorBody = Color;
+}
+
+void CSkinInfoManager::UnsetColorBody(ESkinPrio Priority)
+{
+	m_aOverrideRequests[(int)Priority].m_ColorBody = std::nullopt;
+}
+
+void CSkinInfoManager::SetColorFeet(ESkinPrio Priority, int Color)
+{
+	m_aOverrideRequests[(int)Priority].m_ColorFeet = Color;
+}
+
+void CSkinInfoManager::UnsetColorFeet(ESkinPrio Priority)
+{
+	m_aOverrideRequests[(int)Priority].m_ColorFeet = std::nullopt;
+}
+
+void CSkinInfoManager::SetUseCustomColor(ESkinPrio Priority, bool Value)
+{
+	m_aOverrideRequests[(int)Priority].m_UseCustomColor = Value;
+}
+
+void CSkinInfoManager::UnsetUseCustomColor(ESkinPrio Priority)
+{
+	m_aOverrideRequests[(int)Priority].m_UseCustomColor = std::nullopt;
+}
+
+void CSkinInfoManager::UnsetAll(ESkinPrio Priority)
+{
+	UnsetSkinName(Priority);
+	UnsetColorBody(Priority);
+	UnsetColorFeet(Priority);
+	UnsetUseCustomColor(Priority);
+}
+
+void CSkinInfoManager::SkinName(char *pSkinNameOut, int SizeOfSkinNameOut)
+{
+	for(int i = (int)ESkinPrio::NUM_SKINPRIOS - 1; i > 0; i--)
+	{
+		if(!m_aOverrideRequests[i].m_SkinName.has_value())
+			continue;
+		str_copy(pSkinNameOut, m_aOverrideRequests[i].m_SkinName.value().c_str(), SizeOfSkinNameOut);
+		return;
+	}
+	str_copy(pSkinNameOut, m_TeeInfoUserChoice.m_aSkinName, SizeOfSkinNameOut);
+}
+
+int CSkinInfoManager::ColorBody()
+{
+	for(int i = (int)ESkinPrio::NUM_SKINPRIOS - 1; i > 0; i--)
+	{
+		if(!m_aOverrideRequests[i].m_ColorBody.has_value())
+			continue;
+		return m_aOverrideRequests[i].m_ColorBody.value();
+	}
+	return m_TeeInfoUserChoice.m_ColorBody;
+}
+
+int CSkinInfoManager::ColorFeet()
+{
+	for(int i = (int)ESkinPrio::NUM_SKINPRIOS - 1; i > 0; i--)
+	{
+		if(!m_aOverrideRequests[i].m_ColorFeet.has_value())
+			continue;
+		return m_aOverrideRequests[i].m_ColorFeet.value();
+	}
+	return m_TeeInfoUserChoice.m_ColorFeet;
+}
+
+bool CSkinInfoManager::UseCustomColor()
+{
+	for(int i = (int)ESkinPrio::NUM_SKINPRIOS - 1; i > 0; i--)
+	{
+		if(!m_aOverrideRequests[i].m_UseCustomColor.has_value())
+			continue;
+		return m_aOverrideRequests[i].m_UseCustomColor.value();
+	}
+	return m_TeeInfoUserChoice.m_UseCustomColor;
+}
+
+CTeeInfo CSkinInfoManager::TeeInfo()
+{
+	// TODO: cache this
+	CTeeInfo Info = m_TeeInfoUserChoice;
+	SkinName(Info.m_aSkinName, sizeof(Info.m_aSkinName));
+	Info.m_ColorBody = ColorBody();
+	Info.m_ColorFeet = ColorFeet();
+	Info.m_UseCustomColor = UseCustomColor();
+
+	// TODO: do we need to support setting 0.7 specific skins?
+	Info.ToSixup();
+
+	return Info;
+}

--- a/src/game/server/instagib/skin_info_manager.h
+++ b/src/game/server/instagib/skin_info_manager.h
@@ -1,0 +1,144 @@
+#ifndef GAME_SERVER_INSTAGIB_SKIN_INFO_MANAGER_H
+#define GAME_SERVER_INSTAGIB_SKIN_INFO_MANAGER_H
+
+#include <engine/shared/protocol.h>
+
+#include <game/server/teeinfo.h>
+
+#include <optional>
+#include <string>
+
+enum class ESkinPrio
+{
+	// the skin the client requested
+	USER,
+
+	// priority "low" should be used by the main color
+	// enforced by a gamemode that supports rainbow.
+	// it overwrites the user choice but gets overwritten by
+	// rainbow.
+	// Modes that use this are for example: zCatch
+	LOW,
+
+	// you should never write to this priority or you break rainbow
+	RAINBOW,
+
+	// priority "high" should be used by the main color
+	// enforced by a gamemode that does not support rainbow.
+	// It overwrites the user choice and rainbow.
+	//
+	// Modes that use this are for example: bomb
+	HIGH,
+
+	NUM_SKINPRIOS,
+};
+
+class CSkinOverrideRequest
+{
+public:
+	// TODO: network clipping should be in here but its a bit complicated
+	//       we need to figure out of the value that needs clipping is also applied
+	//       and multiple override requests could apply at once
+	//       so we need figure out if *this* request applied any non nullopt
+	//       value with the priority that was actually used
+
+	// // if set to true the skin change net message for
+	// // 0.7 players will be network clipped to save bandwidth
+	// // this means the skin info is not updating for players
+	// // that are so far away that they don't see each other
+	// //
+	// // WARNING: this will not be resent as soon as the tees get close enough
+	// //          only enable clipping for something spammy that sets a new color every
+	// //          tick. Something like a bomb animation or rainbow.
+	// bool m_NetworkClipped = false;
+
+	bool HasAnyValue();
+
+	// we need a std::string instead of C styled array
+	// to avoid having messy std::optional code
+	// could also use empty C array as unset but then
+	// we can not explicitly set empty skins
+	std::optional<std::string> m_SkinName = std::nullopt;
+	std::optional<bool> m_UseCustomColor = std::nullopt;
+	std::optional<int> m_ColorBody = std::nullopt;
+	std::optional<int> m_ColorFeet = std::nullopt;
+
+	// char m_aaSkinPartNames[protocol7::NUM_SKINPARTS][protocol7::MAX_SKIN_LENGTH] = {"", "", "", "", "", ""};
+	// bool m_aUseCustomColors[protocol7::NUM_SKINPARTS] = {false, false, false, false, false, false};
+	// int m_aSkinPartColors[protocol7::NUM_SKINPARTS] = {0, 0, 0, 0, 0, 0};
+};
+
+// O V E R V I E W:
+//
+// ddnet-insta class to manage skin name and color
+// there is one instance per player and it manages
+// which skin should be used
+// allowing the server to force custom values onto the players
+//
+// L I M I T A T I O N
+//
+// This system only allows one skin per player.
+// So we CAN NOT show one tee in different colors
+// depending on who receives the info.
+//
+// I M P L E M E N T A T I O N:
+//
+// It is implemented by storing the user requested skin
+// using `SetUserChoice()` every time the client sends its skin data.
+//
+// Then any kind of ddnet-insta system can request an overwrite of the skin
+// by using method `NOT_IMPLEMENTED_YET`.
+// That request will stay there until this priority is cleared again explicitly
+// using the method `NOT_IMPLEMENTED_YET`.
+//
+// And then every time the server sends skin data to the clients
+// we fetch the info from `TeeInfo()`
+class CSkinInfoManager
+{
+	// TODO: should this also be a override request?
+	// the tee info requested by the client
+	CTeeInfo m_TeeInfoUserChoice;
+
+	// last info we sent to 0.7 clients
+	CTeeInfo m_LastInfoSent7;
+
+	CSkinOverrideRequest m_aOverrideRequests[(int)ESkinPrio::NUM_SKINPRIOS];
+
+public:
+	bool NeedsNetMessage7();
+	void OnSendNetMessage7();
+	bool ShouldNetworkClip();
+
+	void SetUserChoice(CTeeInfo Info);
+
+	void SetSkinName(ESkinPrio Priority, const char *pSkinName);
+	void UnsetSkinName(ESkinPrio Priority);
+
+	// WARNING: this does not enable custom colors
+	//          so if you actually want to see the color on all tees
+	//          you need to set that too
+	// TODO: should it set both?
+	void SetColorBody(ESkinPrio Priority, int Color);
+	void UnsetColorBody(ESkinPrio Priority);
+
+	void SetColorFeet(ESkinPrio Priority, int Color);
+	void UnsetColorFeet(ESkinPrio Priority);
+
+	void SetUseCustomColor(ESkinPrio Priority, bool Value);
+	void UnsetUseCustomColor(ESkinPrio Priority);
+
+	void UnsetAll(ESkinPrio Priority);
+
+	void SkinName(char *pSkinNameOut, int SizeOfSkinNameOut);
+	int ColorBody();
+	int ColorFeet();
+	bool UseCustomColor();
+
+	// has to be fetched by the server before
+	// sending out info
+	CTeeInfo TeeInfo();
+
+	CTeeInfo UserChoice() { return m_TeeInfoUserChoice; }
+};
+
+#endif

--- a/src/game/server/player.h
+++ b/src/game/server/player.h
@@ -12,6 +12,7 @@
 #include <game/alloc.h>
 #include <game/server/instagib/enums.h>
 #include <game/server/instagib/ip_storage.h>
+#include <game/server/instagib/skin_info_manager.h>
 #include <game/server/instagib/sql_stats.h>
 #include <game/server/instagib/sql_stats_player.h>
 #include <game/server/instagib/structs.h>


### PR DESCRIPTION
The skin info manager now offers controllers a simple interface to request skin colors. There is a central place that determines the ordering so its clear if for example rainbow will work or not. And 0.7 net messages are automatically sent in the background if needed.
    
Closed #463
Closed #457
