### PR TITLE
tees: add server side tees

### DIFF
--- a/src/engine/server/server.cpp
+++ b/src/engine/server/server.cpp
@@ -4675,6 +4675,10 @@ int *CServer::GetIdMap(int ClientId)
 
 bool CServer::SetTimedOut(int ClientId, int OrigId)
 {
+	// ddnet-insta
+	if(m_aClients[ClientId].m_DebugDummy)
+		return false;
+
 	if(!m_NetServer.HasErrored(ClientId))
 	{
 		return false;

--- a/src/engine/shared/network.h
+++ b/src/engine/shared/network.h
@@ -227,6 +227,12 @@ public:
 
 class CNetConnection
 {
+	// ddnet-insta
+public:
+	void OccupySlot();
+	void FreeOccupiedSlot();
+
+private:
 	// TODO: is this needed because this needs to be aware of
 	// the ack sequencing number and is also responsible for updating
 	// that. this should be fixed.
@@ -240,6 +246,9 @@ public:
 		CONNECT,
 		PENDING,
 		ONLINE,
+		// ddnet-insta introduced the OCCUPIED state for server side tees
+		// https://github.com/ddnet-insta/ddnet-insta/pull/500
+		OCCUPIED,
 		ERROR,
 	};
 
@@ -413,6 +422,12 @@ private:
 // server side
 class CNetServer
 {
+	// ddnet-insta
+public:
+	void OccupySlot(int ClientId);
+	void FreeOccupiedSlot(int ClientId);
+
+private:
 	struct CSlot
 	{
 	public:

--- a/src/engine/shared/network_conn.cpp
+++ b/src/engine/shared/network_conn.cpp
@@ -525,6 +525,10 @@ int CNetConnection::Update()
 {
 	int64_t Now = time_get();
 
+	// ddnet-insta
+	if(State() == EState::OCCUPIED)
+		return 0;
+
 	if(State() == EState::ERROR && m_TimeoutSituation && (Now - m_LastRecvTime) > time_freq() * g_Config.m_ConnTimeoutProtection)
 	{
 		m_TimeoutSituation = false;

--- a/src/insta/CMakeLists.txt
+++ b/src/insta/CMakeLists.txt
@@ -9,6 +9,7 @@ function(insta_patch_engine)
     set_src(INSTA_ENGINE_SHARED GLOB_RECURSE src/insta/engine/shared
       # tidy-alphabetical-start
       config_variables_insta.h
+      network.cpp
       # tidy-alphabetical-end
     )
 

--- a/src/insta/engine/server.h
+++ b/src/insta/engine/server.h
@@ -23,6 +23,15 @@ public:
 	virtual bool SixupUsernameAuth(int ClientId, const char *pCredentials) = 0;
 	virtual CAuthManager *AuthManager() = 0;
 
+	// Create a tee from the server side without a actual client connecting to it.
+	// Creates a full player and character instance and uses up a slot.
+	// Returns -1 on error and the new ClientId otherwise.
+	//
+	// WARNING: avoid calling this method. Use the IGameController::CreateTee() wrapper instead.
+	virtual int CreateTee(const char *pName) = 0;
+	virtual void DropTee(int ClientId) = 0;
+	virtual bool IsDebugDummy(int ClientId) const = 0;
+
 private:
 #ifndef IN_CLASS_ENGINE_SERVER
 };

--- a/src/insta/engine/server/server.cpp
+++ b/src/insta/engine/server/server.cpp
@@ -1,3 +1,4 @@
+#include <base/bytes.h>
 #include <base/log.h>
 #include <base/secure.h>
 
@@ -99,4 +100,69 @@ bool CServer::SixupUsernameAuth(int ClientId, const char *pCredentials)
 
 	OnNetMsgRconAuth(ClientId, aName, pPw, true);
 	return true;
+}
+
+int CServer::CreateTee(const char *pName)
+{
+	int ClientId = -1;
+	for(int i = 0; i < MaxClients(); i++)
+	{
+		if(m_aClients[i].m_State != CClient::STATE_EMPTY)
+			continue;
+
+		ClientId = i;
+		break;
+	}
+	if(ClientId == -1)
+		return ClientId;
+
+	CClient &Client = m_aClients[ClientId];
+	NewClientCallback(ClientId, this, false);
+	Client.m_DebugDummy = true;
+
+	// See https://en.wikipedia.org/wiki/Unique_local_address
+	Client.m_DebugDummyAddr.type = NETTYPE_IPV6;
+	Client.m_DebugDummyAddr.ip[0] = 0xfd;
+	// Global ID (40 bits): random
+	secure_random_fill(&Client.m_DebugDummyAddr.ip[1], 5);
+	// Subnet ID (16 bits): constant
+	Client.m_DebugDummyAddr.ip[6] = 0xc0;
+	Client.m_DebugDummyAddr.ip[7] = 0xde;
+	// Interface ID (64 bits): set to client ID
+	Client.m_DebugDummyAddr.ip[8] = 0x00;
+	Client.m_DebugDummyAddr.ip[9] = 0x00;
+	Client.m_DebugDummyAddr.ip[10] = 0x00;
+	Client.m_DebugDummyAddr.ip[11] = 0x00;
+	uint_to_bytes_be(&Client.m_DebugDummyAddr.ip[12], ClientId);
+	// Port: random like normal clients
+	Client.m_DebugDummyAddr.port = secure_rand_below(65535 - 1024) + 1024;
+	net_addr_str(&Client.m_DebugDummyAddr, Client.m_aDebugDummyAddrString.data(), Client.m_aDebugDummyAddrString.size(), true);
+	net_addr_str(&Client.m_DebugDummyAddr, Client.m_aDebugDummyAddrStringNoPort.data(), Client.m_aDebugDummyAddrStringNoPort.size(), false);
+
+	m_NetServer.OccupySlot(ClientId);
+	GameServer()->OnClientConnected(ClientId, nullptr);
+	Client.m_State = CClient::STATE_INGAME;
+	str_copy(Client.m_aName, pName);
+	GameServer()->OnClientEnter(ClientId);
+
+	return ClientId;
+}
+
+void CServer::DropTee(int ClientId)
+{
+	if(ClientId < 0 || ClientId >= MAX_CLIENTS)
+		return;
+	CClient &Client = m_aClients[ClientId];
+	if(!Client.m_DebugDummy)
+		return;
+
+	DelClientCallback(ClientId, "", this);
+	m_NetServer.FreeOccupiedSlot(ClientId);
+}
+
+bool CServer::IsDebugDummy(int ClientId) const
+{
+	if(ClientId < 0 || ClientId >= MAX_CLIENTS)
+		return false;
+	return m_aClients[ClientId].m_DebugDummy;
 }

--- a/src/insta/engine/server/server.h
+++ b/src/insta/engine/server/server.h
@@ -18,6 +18,9 @@ public:
 	CAuthManager *AuthManager() override { return &m_AuthManager; }
 	static void ConRedirect(IConsole::IResult *pResult, void *pUser);
 	bool SixupUsernameAuth(int ClientId, const char *pCredentials) override;
+	int CreateTee(const char *pName) override;
+	void DropTee(int ClientId) override;
+	bool IsDebugDummy(int ClientId) const override;
 
 private:
 #ifndef IN_CLASS_ENGINE_SERVER_SERVER

--- a/src/insta/engine/shared/network.cpp
+++ b/src/insta/engine/shared/network.cpp
@@ -1,0 +1,27 @@
+#include <engine/shared/network.h>
+
+void CNetConnection::OccupySlot()
+{
+	m_State = EState::OCCUPIED;
+}
+
+void CNetConnection::FreeOccupiedSlot()
+{
+	m_State = EState::OFFLINE;
+}
+
+void CNetServer::OccupySlot(int ClientId)
+{
+	if(ClientId >= NET_MAX_CLIENTS)
+		return;
+
+	m_aSlots[ClientId].m_Connection.OccupySlot();
+}
+
+void CNetServer::FreeOccupiedSlot(int ClientId)
+{
+	if(ClientId >= NET_MAX_CLIENTS)
+		return;
+
+	m_aSlots[ClientId].m_Connection.FreeOccupiedSlot();
+}

--- a/src/insta/server/gamecontroller.h
+++ b/src/insta/server/gamecontroller.h
@@ -40,6 +40,29 @@ public:
 	//
 
 	/*
+		Function: CreateTee
+			Call this method to spawn a new tee in the world.
+			It is a server controlled tee with no real client connect to it.
+			That tee will take up a server slot.
+
+		Arguments:
+			pName - The display name of the new tee
+
+		Returns:
+			Client Id of the new tee. Or -1 on error.
+	*/
+	virtual int CreateTee(const char *pName) { return -1; }
+
+	/*
+		Function: DropTee
+			Counter part to CreateTee()
+
+		Arguments:
+			ClientId - Client id returned by CreateTee()
+	*/
+	virtual void DropTee(int ClientId) {}
+
+	/*
 		Function: OnCharacterTakeDamage
 			this function was added in ddnet-insta and is a non standard controller method.
 			neither ddnet nor teeworlds have this

--- a/src/insta/server/gamemodes/insta_core/insta_core.cpp
+++ b/src/insta/server/gamemodes/insta_core/insta_core.cpp
@@ -323,6 +323,9 @@ void CGameControllerInstaCore::InstaCoreDisconnect(CPlayer *pPlayer, const char 
 void CGameControllerInstaCore::PrintDisconnect(CPlayer *pPlayer, const char *pReason)
 {
 	int ClientId = pPlayer->GetCid();
+	if(Server()->IsDebugDummy(ClientId))
+		return;
+
 	if(Server()->ClientIngame(ClientId))
 	{
 		char aBuf[512];
@@ -343,6 +346,9 @@ void CGameControllerInstaCore::PrintDisconnect(CPlayer *pPlayer, const char *pRe
 void CGameControllerInstaCore::PrintConnect(CPlayer *pPlayer, const char *pName)
 {
 	int ClientId = pPlayer->GetCid();
+	if(Server()->IsDebugDummy(ClientId))
+		return;
+
 	if(!Server()->ClientPrevIngame(ClientId))
 	{
 		char aBuf[512];
@@ -565,6 +571,24 @@ void CGameControllerInstaCore::OnFlagCapture(CFlag *pFlag, float Time, int TimeT
 
 	if(IsStatTrack())
 		pPlayer->m_Stats.m_FlagCaptures++;
+}
+
+int CGameControllerInstaCore::CreateTee(const char *pName)
+{
+	int ClientId = Server()->CreateTee(pName);
+	if(ClientId < 0 || ClientId >= MAX_CLIENTS)
+		return -1;
+	CPlayer *pPlayer = GameServer()->m_apPlayers[ClientId];
+	if(!pPlayer)
+		return -1;
+
+	pPlayer->SetAfk(false);
+	return ClientId;
+}
+
+void CGameControllerInstaCore::DropTee(int ClientId)
+{
+	Server()->DropTee(ClientId);
 }
 
 void CGameControllerInstaCore::OnCharacterSpawn(class CCharacter *pChr)

--- a/src/insta/server/gamemodes/insta_core/insta_core.h
+++ b/src/insta/server/gamemodes/insta_core/insta_core.h
@@ -74,6 +74,8 @@ public:
 	void OnFlagGrab(CFlag *pFlag) override;
 	void OnFlagCapture(CFlag *pFlag, float Time, int TimeTicks) override;
 
+	int CreateTee(const char *pName) override;
+	void DropTee(int ClientId) override;
 	void OnCharacterSpawn(class CCharacter *pChr) override;
 	int OnCharacterDeath(class CCharacter *pVictim, class CPlayer *pKiller, int Weapon) override;
 	void Tick() override;


### PR DESCRIPTION
I intentionally branded them as plain as possible. They are often referred to as bots or dummies.

But a dummy can be confused with the dummy from the ddnet client or even the ddnet debug dummies.
The word dummy also already kinda describes its purpose which is limiting.

And a bot sounds like it brings behavior. But we do not know what the gametype wants to do with the tee. They might move on its own they might not.

So we just describe it as is. A tee ready to be used for whatever.

CC #98

Waiting on https://github.com/ddnet/ddnet/pull/11546