### PR TITLE
draft: team change and selfkill code

### DIFF
--- a/src/game/server/gamemodes/insta_core/insta_core.cpp
+++ b/src/game/server/gamemodes/insta_core/insta_core.cpp
@@ -491,6 +491,22 @@ bool CGameControllerInstaCore::CanJoinTeam(int Team, int NotThisId, char *pError
 	return false;
 }
 
+bool CGameControllerInstaCore::CanChangeTeamOrSelfkill(CPlayer *pPlayer, std::optional<int> Team, char *pErrorReason, int ErrorReasonSize)
+{
+	const CCharacter *pChr = pPlayer->GetCharacter();
+	// TODO: think about block gametype here, do we allow team switches while frozen?
+	if(pChr && pChr->m_FreezeTime && !IsDDRaceGameType())
+	{
+		if(Team.has_value())
+			str_format(pErrorReason, ErrorReasonSize, "You can't join %s while being frozen", GetTeamName(Team.value()));
+		else
+			str_copy(pErrorReason, "You can't kill while being frozen", ErrorReasonSize);
+		return false;
+	}
+
+	return IGameController::CanChangeTeamOrSelfkill(pPlayer, Team, pErrorReason, ErrorReasonSize);
+}
+
 bool CGameControllerInstaCore::IsValidTeam(int Team)
 {
 	if(IsTeamPlay())

--- a/src/game/server/gamemodes/insta_core/insta_core.h
+++ b/src/game/server/gamemodes/insta_core/insta_core.h
@@ -70,6 +70,7 @@ public:
 	int GetPlayerTeam(class CPlayer *pPlayer, bool Sixup) override;
 	int GetAutoTeam(int NotThisId) override;
 	bool CanJoinTeam(int Team, int NotThisId, char *pErrorReason, int ErrorReasonSize) override;
+	bool CanChangeTeamOrSelfkill(CPlayer *pPlayer, std::optional<int> Team, char *pErrorReason, int ErrorReasonSize) override;
 	bool IsValidTeam(int Team) override;
 	const char *GetTeamName(int Team) override;
 	bool CanSpawn(int Team, vec2 *pOutPos, int DDTeam) override;

--- a/src/game/server/gamemodes/vanilla/tsmash/tsmash.cpp
+++ b/src/game/server/gamemodes/vanilla/tsmash/tsmash.cpp
@@ -264,5 +264,20 @@ bool CGameControllerTsmash::OnSelfkill(int ClientId)
 	return true;
 }
 
+bool CGameControllerTsmash::CanSelfkill(CPlayer *pPlayer, char *pErrorReason, int ErrorReasonSize)
+{
+	// FIXME: currently team changes are allowed but selfkill is blocked
+	//        do we really want to mix that?
+
+
+	// FIXME: in general what about modes that allow selfkill but not team change
+
+
+	if(pErrorReason)
+		str_copy(pErrorReason, "Self kill is disabled", ErrorReasonSize);
+	return false;
+}
+
+
 REGISTER_GAMEMODE(tsmash, CGameControllerTsmash(pGameServer, false));
 REGISTER_GAMEMODE(ttsmash, CGameControllerTsmash(pGameServer, true));

--- a/src/game/server/gamemodes/vanilla/tsmash/tsmash.h
+++ b/src/game/server/gamemodes/vanilla/tsmash/tsmash.h
@@ -25,7 +25,7 @@ public:
 	void Tick() override;
 	void OnAnyDamage(vec2 &Force, int &Dmg, int &From, int &Weapon, CCharacter *pCharacter) override;
 	bool DecreaseHealthAndKill(int Dmg, int From, int Weapon, CCharacter *pCharacter) override;
-	bool OnSelfkill(int ClientId) override;
+	bool CanSelfkill(class CPlayer *pPlayer, char *pErrorReason, int ErrorReasonSize) override;
 };
 
 #endif

--- a/src/game/server/instagib/gamecontroller.cpp
+++ b/src/game/server/instagib/gamecontroller.cpp
@@ -325,6 +325,26 @@ void IGameController::DoTeamBalance()
 	GameServer()->SendGameMsg(protocol7::GAMEMSG_TEAM_BALANCE, -1);
 }
 
+bool IGameController::CanChangeTeamOrSelfkill(class CPlayer *pPlayer, std::optional<int> Team, char *pErrorReason, int ErrorReasonSize)
+{
+	if(pErrorReason && ErrorReasonSize)
+		pErrorReason[0] = '\0';
+
+	bool AllowedSelfkill = true;
+	if(!Team.has_value())
+		AllowedSelfkill = CanSelfkill(pPlayer, pErrorReason, ErrorReasonSize);
+
+	// Check if changing teams has a error message
+	// if killing is silently blocked.
+	if(!AllowedSelfkill && pErrorReason && pErrorReason[0])
+		return false;
+
+	if(Team.has_value())
+		if(!CanChangeTeam(pPlayer, Team.value(), pErrorReason, ErrorReasonSize))
+			return false;
+	return AllowedSelfkill;
+}
+
 bool IGameController::OnLaserHit(int Bounces, int From, int Weapon, CCharacter *pVictim)
 {
 	if(UnfreezeOnLaserHit())

--- a/src/game/server/instagib/gamecontroller.h
+++ b/src/game/server/instagib/gamecontroller.h
@@ -1096,6 +1096,40 @@ public:
 	*/
 	virtual void RoundInitPlayer(class CPlayer *pPlayer) {}
 
+	// TODO: document
+	virtual bool CanChangeTeam(class CPlayer *pPlayer, int Team, char *pErrorReason, int ErrorReasonSize) { return true; }
+	virtual bool CanSelfkill(class CPlayer *pPlayer, char *pErrorReason, int ErrorReasonSize) { return true; }
+
+	/*
+		Function: CanChangeTeamOrSelfkill
+			This is called when the user initiates a team change or selfkill.
+			Not when the server initiated a team change or kill.
+			So things like team balance, joining the game or round end are not affected by this.
+			For those cases see `CanJoinTeam()`.
+
+			This is also called on tick when there is a pending team change.
+
+			This implements ddnet-insta and mode specific team change and kill limitations.
+			So core blocks like slot limit are handled else where.
+
+			This by default does not allow changing teams or selfkilling while a player is frozen.
+
+			If you need to only block selfkill or team changes and not both.
+			You can override `CanChangeTeam()` and `CanSelfkill()`.
+
+		Arguments:
+			pPlayer - the player that attempted a manual team change or suicide
+			Team - TEAM_RED, TEAM_BLUE or TEAM_SPECTATORS if it is a team change request or nullopt if its a selfkill request
+			pErrorReason - the buffer the error will be written to, only happens on return false
+			               but it can also be empty if it should silently block it
+			ErrorReasonSize - the size of the error buffer in bytes
+
+		Returns:
+			true - if the user action is allowed
+			false - if the user action should be blocked (might write reason to pErrorReason)
+	*/
+	virtual bool CanChangeTeamOrSelfkill(class CPlayer *pPlayer, std::optional<int> Team, char *pErrorReason, int ErrorReasonSize);
+
 	/*
 		Function: DoTeamBalance
 			Makes sure players are evenly distributed


### PR DESCRIPTION
This is for #496 and #495

I am a bit stuck coming up with a good design. I wanted every mode to inherit sane selfkill and team change blocks.
And if a gamemode blocks selfkill the team change should be blocked automatically too. And if a team change is attempted and blocked it should be automatically queued.

But I ran into the following problems:
- Who prints the error? If we want a pure method the error has to be returned as a string. So then the mode can not chose if it is a chat message or a broadcast.
- What if a mode wants to block selfkill but allow team changes
- Too many similar methods OnSelfkill, CanSelfkill, CanJoinTeam, CanChangeTeam