### PR TITLE
Added the ability to shuffle teams at the start of a round

### DIFF
--- a/README.md
+++ b/README.md
@@ -403,6 +403,7 @@ Below is a list of all the settings that were added in ddnet-insta.
 + `sv_bombtag_bomb_weapon` Which weapon should the bomb be given? 0 - Hammer, 1 - Gun, 2 - Shotgun, 3 - Grenade, 4 - Laser, 5 - Ninja
 + `sv_bombtag_collateral_damage` Enable collateral damage, exploding bombs will eliminate any tees in a 3 tile radius.
 + `sv_mystery_rounds_chance` The percentage of a mystery round happening! A random line from sv_mysteryrounds_filename will be executed.
++ `sv_shuffle_on_round_start` Should teams of players be re-assigned each round
 + `sv_spawn_weapons` possible values: grenade, laser
 + `sv_zcatch_colors` Color scheme for zCatch options: teetime, savander
 + `sv_display_score` values: points, round_points, spree, current_spree, win_points, wins, kills, round_kills

--- a/src/engine/shared/config_variables_insta.h
+++ b/src/engine/shared/config_variables_insta.h
@@ -155,3 +155,4 @@ MACRO_CONFIG_INT(SvBombtagCollateralDamage, sv_bombtag_collateral_damage, 0, 0, 
 MACRO_CONFIG_INT(SvMysteryRoundsChance, sv_mystery_rounds_chance, 0, 0, 100, CFGFLAG_SERVER, "The percentage of a mystery round happening! A random line from sv_mysteryrounds_filename will be executed.")
 MACRO_CONFIG_STR(SvMysteryRoundsFileName, sv_mystery_rounds_filename, IO_MAX_PATH_LENGTH, "", CFGFLAG_SERVER, "File which contains mystery round commands, one round per line.")
 MACRO_CONFIG_STR(SvMysteryRoundsResetFileName, sv_mystery_rounds_reset_filename, IO_MAX_PATH_LENGTH, "", CFGFLAG_SERVER, "File which contains the commands to execute after a mystery round.")
+MACRO_CONFIG_INT(SvShuffleOnRoundStart, sv_shuffle_on_round_start, 0, 0, 1, CFGFLAG_SERVER, "Should teams of players be re-assigned each round")

--- a/src/game/server/gamemodes/base_pvp/base_pvp.cpp
+++ b/src/game/server/gamemodes/base_pvp/base_pvp.cpp
@@ -139,6 +139,9 @@ void CGameControllerBasePvp::OnRoundStart()
 
 		RoundInitPlayer(pPlayer);
 	}
+
+	if(Config()->m_SvShuffleOnRoundStart)
+		GameServer()->ShuffleTeams();
 }
 
 void CGameControllerBasePvp::OnRoundEnd()

--- a/src/game/server/instagib/gamecontext.cpp
+++ b/src/game/server/instagib/gamecontext.cpp
@@ -625,6 +625,39 @@ bool CGameContext::IsChatCmdAllowed(int ClientId) const
 	return true;
 }
 
+void CGameContext::ShuffleTeams() const
+{
+	if(!m_pController || !m_pController->IsTeamPlay())
+		return;
+
+	int Rnd = 0;
+	int PlayerTeam = 0;
+	int aPlayer[MAX_CLIENTS];
+
+	for(const CPlayer *pPlayer : m_apPlayers)
+	{
+		if(pPlayer && pPlayer->GetTeam() != TEAM_SPECTATORS)
+			aPlayer[PlayerTeam++] = pPlayer->GetCid();
+	}
+
+	// pSelf->SendGameMsg(GAMEMSG_TEAM_SHUFFLE, -1);
+
+	// creating random permutation
+	for(int i = PlayerTeam; i > 1; i--)
+	{
+		Rnd = rand() % i;
+		int Tmp = aPlayer[Rnd];
+		aPlayer[Rnd] = aPlayer[i - 1];
+		aPlayer[i - 1] = Tmp;
+	}
+
+	// uneven Number of Players?
+	Rnd = PlayerTeam % 2 ? rand() % 2 : 0;
+
+	for(int i = 0; i < PlayerTeam; i++)
+		m_pController->DoTeamChange(m_apPlayers[aPlayer[i]], i < (PlayerTeam + Rnd) / 2 ? TEAM_RED : TEAM_BLUE, false);
+}
+
 void CGameContext::UpdateVoteCheckboxes() const
 {
 	if(!g_Config.m_SvVoteCheckboxes)

--- a/src/game/server/instagib/gamecontext.h
+++ b/src/game/server/instagib/gamecontext.h
@@ -36,6 +36,7 @@ public:
 	void DeepJailIp(int AdminId, const char *pAddrStr, int Minutes);
 	void UndeepJail(CIpStorage *pEntry);
 	void ListDeepJails(int RequesterId) const;
+	void ShuffleTeams() const;
 	void UpdateVoteCheckboxes() const;
 
 	// prints not allowed message in chat for ClientId and returns false

--- a/src/game/server/instagib/rcon_commands.cpp
+++ b/src/game/server/instagib/rcon_commands.cpp
@@ -106,32 +106,7 @@ void CGameContext::ConChat(IConsole::IResult *pResult, void *pUserData)
 void CGameContext::ConShuffleTeams(IConsole::IResult *pResult, void *pUserData)
 {
 	CGameContext *pSelf = (CGameContext *)pUserData;
-	if(!pSelf->m_pController->IsTeamPlay())
-		return;
-
-	int Rnd = 0;
-	int PlayerTeam = 0;
-	int aPlayer[MAX_CLIENTS];
-
-	for(int i = 0; i < MAX_CLIENTS; i++)
-		if(pSelf->m_apPlayers[i] && pSelf->m_apPlayers[i]->GetTeam() != TEAM_SPECTATORS)
-			aPlayer[PlayerTeam++] = i;
-
-	// pSelf->SendGameMsg(GAMEMSG_TEAM_SHUFFLE, -1);
-
-	//creating random permutation
-	for(int i = PlayerTeam; i > 1; i--)
-	{
-		Rnd = rand() % i;
-		int Tmp = aPlayer[Rnd];
-		aPlayer[Rnd] = aPlayer[i - 1];
-		aPlayer[i - 1] = Tmp;
-	}
-	//uneven Number of Players?
-	Rnd = PlayerTeam % 2 ? rand() % 2 : 0;
-
-	for(int i = 0; i < PlayerTeam; i++)
-		pSelf->m_pController->DoTeamChange(pSelf->m_apPlayers[aPlayer[i]], i < (PlayerTeam + Rnd) / 2 ? TEAM_RED : TEAM_BLUE, false);
+	pSelf->ShuffleTeams();
 }
 
 void CGameContext::ConSwapTeams(IConsole::IResult *pResult, void *pUserData)


### PR DESCRIPTION
I moved the logic from CGameContext::ConShuffleTeams to CGameContext::ShuffleTeams and added the ability to shuffle teams at the start of a round

## Checklist

- [x] Tested the change ingame
