### PR TITLE
ddrteams: fix bypass slot limit

### DIFF
--- a/src/insta/server/gamemodes/base_pvp/base_pvp.cpp
+++ b/src/insta/server/gamemodes/base_pvp/base_pvp.cpp
@@ -1209,6 +1209,9 @@ bool CGameControllerBasePvp::OnTeamChatCmd(IConsole::IResult *pResult)
 		return false;
 	}
 
+	if(pResult->NumArguments() == 0 || pResult->GetInteger(0) == TEAM_FLOCK)
+		return false;
+
 	CPlayer *pPlayer = GameServer()->m_apPlayers[pResult->m_ClientId];
 	if(!pPlayer)
 		return false;


### PR DESCRIPTION
The problem was in the arguments and checks in OnTeamChatCmd. if you specify `/team 0` or `/team`, we will enter team 0, this fix fixes this bug and #363

## Checklist

- [x] Tested the change ingame
- [x] I didn't use generative AI to generate more than single-line completions