### PR TITLE
fix: persistent data assert when using ddnet gametype

### DIFF
--- a/src/insta/server/gamecontroller.h
+++ b/src/insta/server/gamecontroller.h
@@ -366,6 +366,15 @@ public:
 			And to load the data again you have to also implement
 			OnClientDataRestore()
 
+			WARNING: be careful if you store gametype specific data here.
+				 if the server changes gametype at runtime with players connected
+				 by running the rcon command "sv_gametype xyz;reload"
+				 the data persistence and loading will be handled by two different
+				 gametype controllers! So there will be data corruption unless
+				 you explicitly handle that case!
+				 So adding new data here should ideally be done in the insta core controller
+				 or in the core controller of your fork which is used for all modes.
+
 		Arguments:
 			pPlayer - the player that is about to be destroyed (read from here)
 			pData - the struct that can store the values across map changes (write to this)
@@ -385,6 +394,10 @@ public:
 
 			And to load the data again you have to also implement
 			OnClientDataRestore()
+
+			WARNING: see the warning section in OnClientDatRestore()
+				 if you override this method and extend it in one gamemode
+				 there will be data corruption on gametype change
 
 		Arguments:
 			pPlayer - the player that is about to be destroyed (write to this)

--- a/src/insta/server/gamemodes/insta_core/insta_core.cpp
+++ b/src/insta/server/gamemodes/insta_core/insta_core.cpp
@@ -1171,6 +1171,7 @@ bool CGameControllerInstaCore::OnSkinChange7(protocol7::CNetMsg_Cl_SkinChange *p
 
 void CGameControllerInstaCore::OnClientDataPersist(CPlayer *pPlayer, CGameContext::CPersistentClientData *pData)
 {
+	pData->m_Insta.m_IsValid = true;
 	pData->m_Insta.m_Addr = *Server()->ClientAddr(pPlayer->GetCid());
 	pData->m_Insta.m_SessionStats = pPlayer->m_SessionStats;
 	pData->m_Insta.m_SessionStats.Merge(&pPlayer->m_Stats);
@@ -1178,6 +1179,12 @@ void CGameControllerInstaCore::OnClientDataPersist(CPlayer *pPlayer, CGameContex
 
 void CGameControllerInstaCore::OnClientDataRestore(CPlayer *pPlayer, const CGameContext::CPersistentClientData *pData)
 {
+	// switched gametype from pure ddnet to a ddnet-insta mode
+	// skip loading uninitialized ddnet-insta data
+	// https://github.com/ddnet-insta/ddnet-insta/issues/669
+	if(!pData->m_Insta.m_IsValid)
+		return;
+
 	// https://github.com/ddnet-insta/ddnet-insta/issues/192
 	// https://github.com/ddnet-insta/ddnet-insta/pull/264#issuecomment-2647909642
 	//

--- a/src/insta/server/persistent_client_data.h
+++ b/src/insta/server/persistent_client_data.h
@@ -5,7 +5,10 @@
 
 #include <insta/server/sql_stats_player.h>
 
-#include <cstdint>
+// WARNING: member initialization is not working here
+//          this is not constructed as a regular C++ object
+//          it is a raw malloc() call and then filled in a callback
+//          https://github.com/ddnet-insta/ddnet-insta/blob/9f70cfac5fe867ef7de406191bfc4f6f502c27d1/src/engine/server/server.cpp#L3136
 
 class CInstaPersistentClientData
 {
@@ -14,6 +17,13 @@ public:
 	//
 	// virtual void OnClientDataPersist(CPlayer *pPlayer, CGameContext::CPersistentClientData *pData) {};
 	// virtual void OnClientDataRestore(CPlayer *pPlayer, const CGameContext::CPersistentClientData *pData) {};
+
+	// when switching from the ddnet gametype to any ddnet-insta gametype
+	// we are going to load persistent client data but only the ddnet part
+	// is actually set and the ddnet-insta part is uninitialized in that
+	// case we need to skip loading it
+	// https://github.com/ddnet-insta/ddnet-insta/issues/669
+	bool m_IsValid;
 
 	NETADDR m_Addr;
 	CSqlStatsPlayer m_SessionStats;


### PR DESCRIPTION
Blocked by https://github.com/ddnet/ddnet/pull/12250
because `m_IsValid` is uninitialized memory otherwise

---

Switching gametype when the previous gametype was ddnet and the new gametype is a ddnet-insta gametype would hit the assert because the ddnet-insta specific data is uninitialized

Closed #669

## Checklist

- [x] Tested the change ingame
- [ ] Provided screenshots if it is a visual change
- [ ] Tested in combination with possibly related configuration options
- [ ] Written a unit test (especially base/) or added coverage to integration test
- [ ] Considered possible null pointers and out of bounds array indexing
- [ ] Changed no physics that affect existing maps
- [ ] Tested the change with [ASan+UBSan or Valgrind's memcheck](https://github.com/ddnet/ddnet/blob/master/docs/DEBUGGING.md#using-addresssanitizer--undefinedbehavioursanitizer-or-valgrinds-memcheck) (optional)
- [x] I didn't use generative AI to generate more than single-line completions