### PR TITLE
logs: log on ddrace start (needs sv_log_race_start)

### DIFF
--- a/ddnet-insta/docs/settings_and_commands.md
+++ b/ddnet-insta/docs/settings_and_commands.md
@@ -137,6 +137,7 @@ Below is a list of all the settings that were added in ddnet-insta.
 + `sv_publish_live_stats` publish the round stats before the round ends as soon as the score changes
 + `sv_live_stats_interval` minimum delay in seconds between stats republish if sv_publish_live_stats is on
 + `sv_clear_stats_on_race_start` Delete players round stats without saving them when touching the start line
++ `sv_log_race_start` Log in console when a player or team starts the race
 + `sv_kill_tile_destroys_ball` Destroy the ball when it touches death tile (only foot)
 + `sv_ball_bounce_friction` The ball looses that much speed after a bounce (only foot)
 + `sv_ball_explode` Should the grenades explode (only foot)

--- a/src/insta/engine/shared/config_variables_insta.h
+++ b/src/insta/engine/shared/config_variables_insta.h
@@ -145,6 +145,7 @@ MACRO_CONFIG_INT(SvPublishLiveStats, sv_publish_live_stats, 0, 0, 1, CFGFLAG_SER
 MACRO_CONFIG_INT(SvLiveStatsInterval, sv_live_stats_interval, 3, 1, 60, CFGFLAG_SERVER, "minimum delay in seconds between stats republish if sv_publish_live_stats is on")
 MACRO_CONFIG_STR(SvRaceStatsHttpEndpoints, sv_race_stats_http_endpoints, 512, "", CFGFLAG_SERVER, "publish stats on finish for each player individually")
 MACRO_CONFIG_INT(SvClearStatsOnRaceStart, sv_clear_stats_on_race_start, 0, 0, 1, CFGFLAG_SERVER, "Delete players round stats without saving them when touching the start line")
+MACRO_CONFIG_INT(SvLogRaceStart, sv_log_race_start, 0, 0, 1, CFGFLAG_SERVER, "Log in console when a player or team starts the race")
 MACRO_CONFIG_INT(SvKillTileDestroysBall, sv_kill_tile_destroys_ball, 0, 0, 1, CFGFLAG_SERVER, "Destroy the ball when it touches death tile (only foot)")
 MACRO_CONFIG_INT(SvBallBounceFriction, sv_ball_bounce_friction, 50, 0, 100000, CFGFLAG_SERVER, "The ball looses that much speed after a bounce (only foot)")
 MACRO_CONFIG_INT(SvBallExplode, sv_ball_explode, 0, 0, 1, CFGFLAG_SERVER, "Should the grenades explode (only foot)")

--- a/src/insta/server/gamecontroller.cpp
+++ b/src/insta/server/gamecontroller.cpp
@@ -944,3 +944,74 @@ void IGameController::OnCreditsChatCmd(IConsole::IResult *pResult, void *pUserDa
 {
 	CGameContext::ConCredits(pResult, pUserData);
 }
+
+bool IGameController::OnRaceStart(int ClientId)
+{
+	if(!g_Config.m_SvLogRaceStart)
+		return false;
+
+	CPlayer *pPlayer = GetPlayerOrNullptr(ClientId);
+	if(!pPlayer)
+		return false;
+
+	const int Team = GameServer()->GetDDRaceTeam(ClientId);
+	if(Team == TEAM_SUPER)
+		return false;
+
+	if(Team == TEAM_FLOCK)
+	{
+		if(Teams().GetDDRaceState(pPlayer) != ERaceState::STARTED)
+		{
+			log_info("game", "'%s' has started the race.", Server()->ClientName(ClientId));
+		}
+		return false;
+	}
+
+	if(Teams().GetTeamState(Team) >= ETeamState::STARTED)
+		return false;
+
+	int aTeamMembers[MAX_CLIENTS];
+	int NumMembers = 0;
+	for(int i = 0; i < MAX_CLIENTS; ++i)
+	{
+		CPlayer *pMember = GetPlayerOrNullptr(i);
+		if(pMember && pMember->IsPlaying() && GameServer()->GetDDRaceTeam(i) == Team)
+		{
+			aTeamMembers[NumMembers++] = i;
+		}
+	}
+
+	if(NumMembers == 0)
+		return false;
+
+	if(NumMembers == 1)
+	{
+		log_info("game", "'%s' has started the race.", Server()->ClientName(aTeamMembers[0]));
+		return false;
+	}
+
+	char aNamesBuf[MAX_CLIENTS * (MAX_NAME_LENGTH + 3)] = "";
+	for(int i = 0; i < NumMembers; ++i)
+	{
+		char aFormattedName[MAX_NAME_LENGTH + 2];
+		str_format(aFormattedName, sizeof(aFormattedName), "'%s'", Server()->ClientName(aTeamMembers[i]));
+
+		if(i == 0)
+		{
+			str_copy(aNamesBuf, aFormattedName);
+		}
+		else if(i == NumMembers - 1)
+		{
+			str_append(aNamesBuf, " & ");
+			str_append(aNamesBuf, aFormattedName);
+		}
+		else
+		{
+			str_append(aNamesBuf, ", ");
+			str_append(aNamesBuf, aFormattedName);
+		}
+	}
+
+	log_info("game", "%s has started the race in team %d", aNamesBuf, Team);
+	return false;
+}

--- a/src/insta/server/gamecontroller.h
+++ b/src/insta/server/gamecontroller.h
@@ -747,7 +747,7 @@ public:
 		Returns:
 			return true to not run the ddnet code and abort the start
 	*/
-	virtual bool OnRaceStart(int ClientId) { return false; }
+	virtual bool OnRaceStart(int ClientId);
 
 	/*
 		Function: OnChangeInfoNetMessage

--- a/src/insta/server/gamemodes/insta_core/insta_core.cpp
+++ b/src/insta/server/gamemodes/insta_core/insta_core.cpp
@@ -1611,7 +1611,7 @@ bool CGameControllerInstaCore::OnRaceStart(int ClientId)
 		if(pPlayer)
 			pPlayer->ResetStats();
 	}
-	return false;
+	return IGameController::OnRaceStart(ClientId);
 }
 
 bool CGameControllerInstaCore::IsPlaying(const CPlayer *pPlayer)


### PR DESCRIPTION
Closes #664.

- [x] I didn't use generative AI to generate more than single-line completions